### PR TITLE
lint staged files on pre-commit

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yarn lint

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "start": "next start",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "lint": "yarn eslint --no-error-on-unmatched-pattern $(git diff --name-only HEAD $(git merge-base HEAD origin/main) | grep -E '\\.(ts|tsx)$' | xargs)",
+    "lint": "yarn eslint --no-error-on-unmatched-pattern $(git diff --name-only --cached | grep -E *.tsx?$ | xargs)",
     "lint:all": "yarn eslint .",
-    "lint:in": "yarn eslint"
+    "lint:in": "yarn eslint",
+    "preinstall": "git config core.hooksPath git-hooks"
   },
   "dependencies": {
     "@ethersproject/keccak256": "^5.4.0",


### PR DESCRIPTION
This PR sets up a pre-commit hook that runs the linter on staged `.ts` and `.tsx` files. Right before running `yarn install` it registers the hook with git, and it should just be automagic from there. In the event we need to get past the lint requirement we can always disable the hook with `git commit -n`.