### PR TITLE
fix: don't wrap Input messages in <p> by default

### DIFF
--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -62,7 +62,7 @@ export const Input: FunctionComponent<InputProps> = ({
           {...props}
         />
       </label>
-      {hasError && <p className={styles.errorMessage}>{error}</p>}
+      {hasError && <div className={styles.errorMessage}>{error}</div>}
       {hasMessage && message}
     </div>
   );


### PR DESCRIPTION
Messages sometimes have a tooltip, and the tooltip component uses divs. It's invalid to wrap divs inside ps (though most browsers Do The Right Thing). This spruces up our inputs not to wrap input with <p> tags by default -- we can leave the semantics up to the consumer

resolves #79 