### PR TITLE
fix: enforce square aspect ratio on media

### DIFF
--- a/components/Media/Media.module.css
+++ b/components/Media/Media.module.css
@@ -1,3 +1,4 @@
 .media-content {
   width: 100%;
+  aspect-ratio: 1/1;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/143060585-e8cf434a-ccd5-44ce-b329-8f10ee951300.png)

This way, when we get an error or something we keep them all square