### PR TITLE
feat: AccountProvider connects automatically

### DIFF
--- a/context/account.tsx
+++ b/context/account.tsx
@@ -1,5 +1,10 @@
 import noop from 'lodash/noop';
-import React, { createContext, FunctionComponent, useState } from 'react';
+import React, {
+  createContext,
+  FunctionComponent,
+  useEffect,
+  useState,
+} from 'react';
 
 type AccountContext = {
   /** The address of the connected wallet, if present. */
@@ -15,6 +20,31 @@ export const AccountContext = createContext<AccountContext>({
 
 export const AccountProvider: FunctionComponent = ({ children }) => {
   const [account, setAccount] = useState<string | null>(null);
+
+  // On first load, see if there's already a connected account.
+  useEffect(() => {
+    if (window.ethereum) {
+      window.ethereum.sendAsync(
+        {
+          method: 'eth_accounts',
+          params: [],
+          jsonrpc: '2.0',
+          id: new Date().getTime(),
+        },
+        (error: any, result: any) => {
+          if (error) {
+            console.error(error);
+          } else {
+            const addressList = result.result;
+            if (addressList && addressList.length > 0) {
+              setAccount(addressList[0]);
+            }
+          }
+        },
+      );
+    }
+  });
+
   return (
     <AccountContext.Provider value={{ account, setAccount }}>
       {children}


### PR DESCRIPTION
resolves #103 

When initializing the app, `AccountProvider` checks to see if there are any accounts already connected. If so, we set that right off the bat. Otherwise, behavior is same as before requiring user to press the "Connect Wallet" button.