### PR TITLE
chore: update LoanInfo nomenclature

### DIFF
--- a/components/ticketPage/RepayCard.tsx
+++ b/components/ticketPage/RepayCard.tsx
@@ -49,9 +49,7 @@ export function RepayCard({ loanInfo, repaySuccessCallback }: RepayCardProps) {
       loanInfo.loanAssetDecimals,
     );
     const ticketHolder =
-      loanInfo.ticketOwner.slice(0, 10) +
-      '...' +
-      loanInfo.ticketOwner.slice(34, 42);
+      loanInfo.borrower.slice(0, 10) + '...' + loanInfo.borrower.slice(34, 42);
     return { repayAmount, ticketHolder };
   }, [amountOwed, loanInfo]);
 

--- a/lib/LoanInfoType.ts
+++ b/lib/LoanInfoType.ts
@@ -13,7 +13,7 @@ export type LoanInfo = {
   closed: boolean;
   loanAssetDecimals: number;
   loanAssetSymbol: string;
-  loanOwner: string | null;
-  ticketOwner: string;
+  lender: string | null;
+  borrower: string;
   interestOwed: ethers.BigNumber;
 };

--- a/lib/loan.ts
+++ b/lib/loan.ts
@@ -31,15 +31,15 @@ export async function getLoanInfo(id: string): Promise<LoanInfo> {
 
   const decimals = await assetContract.decimals();
   const loanAssetSymbol = await assetContract.symbol();
-  let loanOwner = null;
+  let lender = null;
   if (!lastAccumulatedTimestamp.eq(0)) {
-    loanOwner = await lendTicket.ownerOf(loanId);
+    lender = await lendTicket.ownerOf(loanId);
     // const interest = await loanFacilitator.interestOwed(loanId);
     // const scalar = await loanFacilitator.SCALAR();
   }
 
   const interestOwed = await loanFacilitator.interestOwed(loanId);
-  const ticketOwner = await borrowTicket.ownerOf(loanId);
+  const borrower = await borrowTicket.ownerOf(loanId);
 
   return {
     loanId,
@@ -54,8 +54,8 @@ export async function getLoanInfo(id: string): Promise<LoanInfo> {
     closed,
     loanAssetDecimals: parseInt(decimals.toString()),
     loanAssetSymbol,
-    loanOwner,
-    ticketOwner,
+    lender,
+    borrower,
     interestOwed,
   };
 }


### PR DESCRIPTION
resolves #121 

Renaming `loanOwner` to `lender` and `ticketOwner` to borrower. Additionally, on the ticket page we can just use the values in `loanInfo` rather than fetching owners separately