### PR TITLE
fix: remove unneeded state update in RepayCard

### DIFF
--- a/components/ticketPage/RepayCard.tsx
+++ b/components/ticketPage/RepayCard.tsx
@@ -19,9 +19,6 @@ interface RepayCardProps {
 export function RepayCard({ loanInfo, repaySuccessCallback }: RepayCardProps) {
   const { account } = useContext(AccountContext);
   const [disabled, setDisabled] = useState(false);
-  const [allowanceValue, setAllowanceValue] = useState(
-    ethers.BigNumber.from('0'),
-  );
   const [needsAllowance, setNeedsAllowance] = useState(false);
   const [amountOwed] = useState(loanInfo.interestOwed.add(loanInfo.loanAmount));
 
@@ -36,7 +33,6 @@ export function RepayCard({ loanInfo, repaySuccessCallback }: RepayCardProps) {
       setNeedsAllowance(allowance.lt(amountOwed));
     }
     setDisabled(allowance.lt(amountOwed));
-    setAllowanceValue(allowance);
   };
 
   useEffect(() => {


### PR DESCRIPTION
resolves #132 

Not 100% clear on why this is happening, but this unused `allowanceValue` seemed to cause `RepayCard` to constantly re-render, which would cause us to repeatedly call the alchemy api. Now we make fewer requests and stop until we next poll again, a much calmer outcome.