### PR TITLE
fix: use TransactionButton on SeizeCollateralCard

### DIFF
--- a/components/ticketPage/SeizeCollateralCard.tsx
+++ b/components/ticketPage/SeizeCollateralCard.tsx
@@ -64,7 +64,8 @@ export default function SeizeCollateralCard({
       <p>
         The loan duration is complete. The total interest and principal owed is{' '}
         {totalOwed}, and 0 {loanInfo.loanAssetSymbol} has been repaid. You are
-        able to seize the collateral NFT, closing the loan, or wait for seizure.
+        able to seize the collateral NFT, closing the loan, or wait for
+        repayment.
       </p>
       <TransactionButton
         text="seize collateral"


### PR DESCRIPTION
This PR resolves #100.

Using `TransactionButton` on the action here, and also some small terminology updates.