### PR TITLE
fix: [safari] explicit dimensions on wallet SVGs

### DIFF
--- a/components/Button/Button.module.css
+++ b/components/Button/Button.module.css
@@ -45,6 +45,8 @@
 }
 
 .button-grid-wrapper > svg {
+  height: 49px;
+  width: 49px;
   max-height: 49px;
   max-width: 49px;
 }


### PR DESCRIPTION
For some reason Safari defaults to rendering these SVGs with no width or height. Setting them explicitly resolves.