### PR TITLE
fix: simpler font import

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,9 @@
 import '../styles/global.css';
+import '../public/fonts/maru/fonts-maru.css';
 import 'normalize.css';
 import { AppProps } from 'next/app';
 import { Web3ReactProvider } from '@web3-react/core';
 import { Web3Provider } from '@ethersproject/providers';
-import Head from 'next/head';
 
 const getLibrary: React.ComponentProps<typeof Web3ReactProvider>['getLibrary'] =
   (provider) => {
@@ -15,9 +15,6 @@ const getLibrary: React.ComponentProps<typeof Web3ReactProvider>['getLibrary'] =
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <Web3ReactProvider getLibrary={getLibrary}>
-      <Head>
-        <link href="fonts/maru/fonts-maru.css" rel="stylesheet" />
-      </Head>
       <Component {...pageProps} />
     </Web3ReactProvider>
   );


### PR DESCRIPTION
noticed we had this lint error due to the way I did the font CSS import:
```
./pages/_app.tsx
19:9  Warning: Do not include stylesheets manually. See: https://nextjs.org/docs/messages/no-css-tags.  @next/next/no-css-tags
```

:thinking: not actually sure why I did it this way to begin with, updating to the recommended pattern