### PR TITLE
dev: add coverage command

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   collectCoverageFrom: [
-    '**/*.{js,jsx,ts,tsx}',
+    'components/**/*.{js,jsx,ts,tsx}',
+    'lib/**/*.{js,jsx,ts,tsx}',
+    '!**/index.ts',
     '!**/*.d.ts',
     '!**/node_modules/**',
   ],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,json}\"",
     "prepare": "husky install",
     "typecheck": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "test-coverage": "yarn test --collect-coverage=true"
   },
   "dependencies": {
     "@ethersproject/keccak256": "^5.4.0",


### PR DESCRIPTION
This PR adds a script `yarn test-coverage` which will run tests and create a coverage report. Not making this the default since coverage can be a bit slow. Right now this collects coverage on the following directories:

- components
- hooks
- lib
