### PR TITLE
feat: add DescriptionList

### DIFF
--- a/components/DescriptionList/DescriptionList.module.css
+++ b/components/DescriptionList/DescriptionList.module.css
@@ -1,0 +1,19 @@
+/* Note: this styling is not compatible with "multiple terms, single definition". */
+.dl {
+  display: grid;
+  grid-template-columns: fit-content(50%) 1fr;
+  column-gap: var(--gap);
+  align-items: center;
+}
+
+.dl > dd {
+  margin: 0;
+}
+
+.dl > dt {
+  margin: 0;
+  text-transform: uppercase;
+  text-align: right;
+  font-size: var(--font-small);
+  letter-spacing: 12%;
+}

--- a/components/DescriptionList/DescriptionList.tsx
+++ b/components/DescriptionList/DescriptionList.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styles from './DescriptionList.module.css';
+
+interface DescriptionListProps
+  extends React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLDListElement>,
+    HTMLDListElement
+  > {}
+
+export const DescriptionList = ({ children }: DescriptionListProps) => {
+  return <dl className={styles.dl}>{children}</dl>;
+};

--- a/components/DescriptionList/index.ts
+++ b/components/DescriptionList/index.ts
@@ -1,0 +1,1 @@
+export { DescriptionList } from './DescriptionList';

--- a/stories/DescriptionList.stories.tsx
+++ b/stories/DescriptionList.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { DescriptionList } from 'components/DescriptionList';
+
+export default {
+  title: 'components/DescriptionList',
+  component: DescriptionList,
+};
+
+export const List = () => (
+  <DescriptionList>
+    <dt>Beast of Bodmin</dt>
+    <dd>A large feline inhabiting Bodmin Moor.</dd>
+
+    <dt>Morgawr</dt>
+    <dd>A sea serpent.</dd>
+
+    <dt>Owlman</dt>
+    <dd>A giant owl-like creature.</dd>
+  </DescriptionList>
+);


### PR DESCRIPTION
A semantic component for key/value pairs, like the info we show on the new loan page header