### PR TITLE
fix: refresh uses nodeLoanById

### DIFF
--- a/pages/loans/[id].tsx
+++ b/pages/loans/[id].tsx
@@ -7,6 +7,7 @@ import { LoanHeader } from 'components/LoanHeader';
 import { LoanInfo } from 'components/LoanInfo';
 import { CollateralMedia } from 'types/CollateralMedia';
 import { getNFTInfoFromTokenInfo } from 'lib/getNFTInfo';
+import { nodeLoanById } from 'lib/loans/node/nodeLoanById';
 
 export type LoanPageProps = {
   loanInfoJson: string;
@@ -43,7 +44,7 @@ export default function Loans({ loanInfoJson }: LoanPageProps) {
     useState<CollateralMedia | null>(null);
 
   const refresh = useCallback(() => {
-    loanById(loan.id.toString()).then((loan) => {
+    nodeLoanById(loan.id.toString()).then((loan) => {
       if (loan) {
         setLoan(loan);
       }


### PR DESCRIPTION
This PR fixes #238. Foolishly, I used the subgraph api instead of the node api