### PR TITLE
fix: spelling in authorization explainer

### DIFF
--- a/components/CreatePageHeader/explainers.tsx
+++ b/components/CreatePageHeader/explainers.tsx
@@ -35,7 +35,7 @@ function ExplainerNeedsToAuthorize() {
   return (
     <div className={styles.explainer}>
       This allows the Pawn Shop to hold your NFT until you repay any loan you
-      receive, and to trasnfer it to the lender if you choose not to repay.
+      receive, and to transfer it to the lender if you choose not to repay.
     </div>
   );
 }


### PR DESCRIPTION
spotted a little spelling error