### PR TITLE
Remove unneeded waits for events

### DIFF
--- a/components/Button/AllowButton.tsx
+++ b/components/Button/AllowButton.tsx
@@ -22,19 +22,6 @@ export function AllowButton({
   const [txHash, setTxHash] = useState('');
   const [waitingForTx, setWaitingForTx] = useState(false);
 
-  const waitForApproval = useCallback(() => {
-    const contract = jsonRpcERC20Contract(contractAddress);
-    const filter = contract.filters.Approval(
-      account,
-      process.env.NEXT_PUBLIC_NFT_LOAN_FACILITATOR_CONTRACT,
-      null,
-    );
-    contract.once(filter, () => {
-      callback();
-      setWaitingForTx(false);
-    });
-  }, [account, callback, contractAddress]);
-
   const allow = useCallback(async () => {
     const contract = web3Erc20Contract(contractAddress);
     const t = await contract.approve(
@@ -45,14 +32,14 @@ export function AllowButton({
     setTxHash(t.hash);
     t.wait()
       .then(() => {
-        setWaitingForTx(true);
-        waitForApproval();
+        callback();
+        setWaitingForTx(false);
       })
       .catch((err) => {
         setWaitingForTx(false);
         console.log(err);
       });
-  }, [contractAddress, waitForApproval]);
+  }, [contractAddress]);
 
   const buttonText = useMemo(() => `Authorize ${symbol}`, [symbol]);
 

--- a/components/CreatePageHeader/CreatePageHeader.tsx
+++ b/components/CreatePageHeader/CreatePageHeader.tsx
@@ -140,25 +140,6 @@ function AuthorizeNFTButton({
   const { account } = useWeb3();
   const [transactionHash, setTransactionHash] = useState('');
 
-  const waitForApproval = useCallback(async () => {
-    const contract = jsonRpcERC721Contract(collateralAddress);
-    const filter = contract.filters.Approval(
-      account,
-      process.env.NEXT_PUBLIC_NFT_LOAN_FACILITATOR_CONTRACT,
-      collateralTokenID,
-    );
-    contract.once(filter, () => {
-      setSubmittingApproval(false);
-      setIsCollateralApproved(true);
-    });
-  }, [
-    account,
-    collateralAddress,
-    setIsCollateralApproved,
-    collateralTokenID,
-    setSubmittingApproval,
-  ]);
-
   const approve = useCallback(async () => {
     const web3Contract = web3Erc721Contract(collateralAddress);
     const t = await web3Contract.approve(
@@ -169,19 +150,14 @@ function AuthorizeNFTButton({
     setSubmittingApproval(true);
     t.wait()
       .then(() => {
-        waitForApproval();
-        setSubmittingApproval(true);
+        setSubmittingApproval(false);
+        setIsCollateralApproved(true);
       })
       .catch((err) => {
         setSubmittingApproval(false);
         console.error(err);
       });
-  }, [
-    collateralAddress,
-    waitForApproval,
-    collateralTokenID,
-    setSubmittingApproval,
-  ]);
+  }, [collateralAddress, collateralTokenID, setSubmittingApproval]);
   const text = useMemo(() => 'Authorize NFT', []);
   const isDisabled = state < State.NeedsToAuthorize;
 

--- a/components/LoanForm/LoanFormEarlyClosure.tsx
+++ b/components/LoanForm/LoanFormEarlyClosure.tsx
@@ -23,12 +23,8 @@ export function LoanFormEarlyClosure({
 
     t.wait()
       .then(() => {
-        const loanFacilitator = jsonRpcLoanFacilitator();
-        const filter = loanFacilitator.filters.Close(loan.id);
-        loanFacilitator.once(filter, () => {
-          setIsPending(false);
-          refresh();
-        });
+        setIsPending(false);
+        refresh();
       })
       .catch((err) => {
         setIsPending(false);

--- a/components/LoanForm/LoanFormRepay.tsx
+++ b/components/LoanForm/LoanFormRepay.tsx
@@ -30,30 +30,20 @@ export function LoanFormRepay({
   const [txHash, setTxHash] = useState('');
   const [waitingForTx, setWaitingForTx] = useState(false);
 
-  const wait = useCallback(async () => {
-    const loanFacilitator = jsonRpcLoanFacilitator();
-    const filter = loanFacilitator.filters.Repay(loan.id);
-    loanFacilitator.once(filter, () => {
-      refresh();
-      setWaitingForTx(false);
-    });
-  }, [loan.id, refresh]);
-
   const repay = useCallback(async () => {
     const t = await web3LoanFacilitator().repayAndCloseLoan(loan.id);
     setWaitingForTx(true);
     setTxHash(t.hash);
     t.wait()
       .then(() => {
-        setTxHash(t.hash);
-        setWaitingForTx(true);
-        wait();
+        refresh();
+        setWaitingForTx(false);
       })
       .catch((err) => {
         setWaitingForTx(false);
         console.error(err);
       });
-  }, [loan.id, wait]);
+  }, [loan.id]);
 
   return (
     <div className={styles.form}>

--- a/components/LoanForm/LoanFormSeizeCollateral.tsx
+++ b/components/LoanForm/LoanFormSeizeCollateral.tsx
@@ -23,12 +23,8 @@ export function LoanFormSeizeCollateral({
 
     t.wait()
       .then(() => {
-        const loanFacilitator = jsonRpcLoanFacilitator();
-        const filter = loanFacilitator.filters.SeizeCollateral(loan.id);
-        loanFacilitator.once(filter, () => {
-          setIsPending(false);
-          refresh();
-        });
+        setIsPending(false);
+        refresh();
       })
       .catch((err) => {
         setIsPending(false);

--- a/components/ticketPage/SeizeCollateralCard.tsx
+++ b/components/ticketPage/SeizeCollateralCard.tsx
@@ -36,25 +36,16 @@ export default function SeizeCollateralCard({
       // If they've gotten this far, they have an account.
       account as string,
     );
+    setTxHash(t.hash);
     t.wait()
-      .then((receipt) => {
-        setTxHash(t.hash);
-        setWaitingForTx(true);
-        wait();
+      .then(() => {
+        seizeCollateralSuccessCallback();
+        setWaitingForTx(false);
       })
       .catch((err) => {
         setWaitingForTx(false);
         console.log(err);
       });
-  };
-
-  const wait = async () => {
-    const loanFacilitator = jsonRpcLoanFacilitator();
-    const filter = loanFacilitator.filters.SeizeCollateral(loanInfo.id);
-    loanFacilitator.once(filter, () => {
-      seizeCollateralSuccessCallback();
-      setWaitingForTx(false);
-    });
   };
 
   const totalOwed = `${amountOwed} ${loanInfo.loanAssetSymbol}`;

--- a/hooks/useLoanUnderwriter/useLoanUnderwriter.ts
+++ b/hooks/useLoanUnderwriter/useLoanUnderwriter.ts
@@ -43,12 +43,8 @@ export function useLoanUnderwriter(
       setTxHash(t.hash);
       t.wait()
         .then(() => {
-          const loanFacilitator = jsonRpcLoanFacilitator();
-          const filter = loanFacilitator.filters.UnderwriteLoan(id, account);
-          loanFacilitator.once(filter, () => {
-            setTransactionPending(false);
-            refresh();
-          });
+          setTransactionPending(false);
+          refresh();
         })
         .catch((err) => {
           setTransactionPending(false);


### PR DESCRIPTION
I realized that I had defaulted our buttons to waiting for an event to be emitted, but this is not necessary, causes extra delay, and sometimes doesn't resolve at all! We only need to do this if we need an emitted value, like on loan creation we need to know the new loan ID. 

`wait` by default is waiting until the tx is included. 