### PR TITLE
fix: only lender can seize collateral

### DIFF
--- a/components/LoanForm/LoanForm.tsx
+++ b/components/LoanForm/LoanForm.tsx
@@ -76,7 +76,10 @@ export function LoanForm({ loan, refresh }: LoanFormProps) {
 
   if (
     !loan.lastAccumulatedTimestamp.eq(0) &&
-    loan.lastAccumulatedTimestamp.add(loan.durationSeconds).lte(timestamp || 0)
+    loan.lastAccumulatedTimestamp
+      .add(loan.durationSeconds)
+      .lte(timestamp || 0) &&
+    account.toLowerCase() === loan.lender?.toLowerCase()
   ) {
     if (account.toUpperCase() === loan.lender?.toUpperCase()) {
       return <LoanFormSeizeCollateral loan={loan} refresh={refresh} />;


### PR DESCRIPTION
This PR fixes #271. Now when a loan is past due, the `seize collateral` button should only show up for the lender. For others it will fall through to the `offer better terms` form