### PR TITLE
Fix visual bug in profile page

### DIFF
--- a/components/Profile/BorrowerLenderBubble.tsx
+++ b/components/Profile/BorrowerLenderBubble.tsx
@@ -20,8 +20,12 @@ export function BorrowerLenderBubble({ address, borrower }: BubblesProps) {
         borrower ? styles.borrowerBubble : styles.lenderBubble
       }`}>
       {isConnectedUser && `You are the ${borrower ? 'borrower' : 'lender'}`}
-      {!isConnectedUser && `${borrower ? 'Borrower' : 'Lender'} `}
-      <span>{address.substring(0, 7)}</span>
+      {!isConnectedUser && (
+        <>
+          {borrower ? 'Borrower' : 'Lender'}{' '}
+          <span>{address.substring(0, 7)}</span>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
We were rendering the span with the users address even if the user had their wallet connected. Should only show if not connected