### PR TITLE
fix: actually fix 500 error on post-create

### DIFF
--- a/lib/loans/subgraph/subgraphLoanEventsById.ts
+++ b/lib/loans/subgraph/subgraphLoanEventsById.ts
@@ -38,22 +38,26 @@ export async function subgraphLoanHistoryById(id: string): Promise<Event[]> {
 
   const events: Event[] = [];
 
-  if (loan.createEvent && loan.createEvent !== null) {
+  if (!loan) {
+    return events;
+  }
+
+  if (loan.createEvent) {
     const event = loan.createEvent as CreateEvent;
     events.push(createEventToUnified(event));
   }
 
-  if (loan.closeEvent && loan.closeEvent !== null) {
+  if (loan.closeEvent) {
     const event = loan.closeEvent as CloseEvent;
     events.push(closeEventToUnified(event));
   }
 
-  if (loan.collateralSeizureEvent && loan.collateralSeizureEvent !== null) {
+  if (loan.collateralSeizureEvent) {
     const event = loan.collateralSeizureEvent as CollateralSeizureEvent;
     events.push(collateralSeizureEventToUnified(event));
   }
 
-  if (loan.repaymentEvent && loan.repaymentEvent !== null) {
+  if (loan.repaymentEvent) {
     const event = loan.repaymentEvent as RepaymentEvent;
     events.push(repaymentEventToUnified(event));
   }


### PR DESCRIPTION
This fixes the error that occurs when the graph hasn't indexed a just-created transaction but we try to load the page (e.g., immediately after completing the create flow). The error could also be triggered by trying to go to a loan page that doesn't exist (we'd get a 500 instead of the expected 404).