### PR TITLE
test: boost coverage on Button components

### DIFF
--- a/__tests__/components/Button.test.tsx
+++ b/__tests__/components/Button.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AllowButton, Button, DialogDisclosureButton } from 'components/Button';
+import { authorizeCurrency } from 'lib/authorizations/authorizeCurrency';
+
+jest.mock('lib/authorizations/authorizeCurrency', () => ({
+  ...jest.requireActual('lib/authorizations/authorizeCurrency'),
+  authorizeCurrency: jest.fn(),
+}));
+
+describe('Button Components', () => {
+  describe('AllowButton', () => {
+    const contractAddress = '0xaddress';
+    const symbol = 'SYM';
+    let callback = jest.fn();
+    beforeEach(() => {
+      callback = jest.fn();
+    });
+    it('calls the approve method when clicked', () => {
+      const { getByText } = render(
+        <AllowButton
+          contractAddress={contractAddress}
+          symbol={symbol}
+          callback={callback}
+        />,
+      );
+      const button = getByText(`Authorize ${symbol}`);
+      userEvent.click(button);
+      expect(authorizeCurrency).toHaveBeenCalled();
+    });
+    it('renders a finished state when done', () => {
+      const { getByText } = render(
+        <AllowButton
+          contractAddress={contractAddress}
+          symbol={symbol}
+          callback={callback}
+          done={true}
+        />,
+      );
+      getByText('Permission granted');
+    });
+  });
+
+  describe('Button', () => {
+    it('calls its onClick when clicked', () => {
+      const handleClick = jest.fn();
+      const { getByText } = render(
+        <Button onClick={handleClick}>Hello</Button>,
+      );
+      const button = getByText('Hello');
+      expect(handleClick).not.toHaveBeenCalled();
+      userEvent.click(button);
+      expect(handleClick).toHaveBeenCalled();
+    });
+  });
+
+  describe('DialogDisclosureButton', () => {
+    it('calls its onClick when clicked', () => {
+      const handleClick = jest.fn();
+      const { getByText } = render(
+        <DialogDisclosureButton onClick={handleClick}>
+          Hello
+        </DialogDisclosureButton>,
+      );
+      const button = getByText('Hello');
+      expect(handleClick).not.toHaveBeenCalled();
+      userEvent.click(button);
+      expect(handleClick).toHaveBeenCalled();
+    });
+  });
+});

--- a/components/Button/AllowButton.tsx
+++ b/components/Button/AllowButton.tsx
@@ -1,9 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
-import { ethers } from 'ethers';
 import { TransactionButton } from 'components/Button';
-import { web3Erc20Contract } from 'lib/contracts';
-import { useWeb3 } from 'hooks/useWeb3';
 import { CompletedButton } from 'components/Button';
+import { authorizeCurrency } from 'lib/authorizations/authorizeCurrency';
 
 interface AllowButtonProps {
   contractAddress: string;
@@ -18,28 +16,17 @@ export function AllowButton({
   callback,
   done,
 }: AllowButtonProps) {
-  const { account } = useWeb3();
   const [txHash, setTxHash] = useState('');
   const [waitingForTx, setWaitingForTx] = useState(false);
 
-  const allow = useCallback(async () => {
-    const contract = web3Erc20Contract(contractAddress);
-    const t = await contract.approve(
-      process.env.NEXT_PUBLIC_NFT_LOAN_FACILITATOR_CONTRACT || '',
-      ethers.BigNumber.from(2).pow(256).sub(1),
-    );
-    setWaitingForTx(true);
-    setTxHash(t.hash);
-    t.wait()
-      .then(() => {
-        callback();
-        setWaitingForTx(false);
-      })
-      .catch((err) => {
-        setWaitingForTx(false);
-        console.log(err);
-      });
-  }, [callback, contractAddress]);
+  const allow = useCallback(() => {
+    authorizeCurrency({
+      callback,
+      contractAddress,
+      setTxHash,
+      setWaitingForTx,
+    });
+  }, [callback, contractAddress, setTxHash, setWaitingForTx]);
 
   const buttonText = useMemo(() => `Authorize ${symbol}`, [symbol]);
 

--- a/lib/authorizations/authorizeCurrency.ts
+++ b/lib/authorizations/authorizeCurrency.ts
@@ -1,0 +1,32 @@
+import { ethers } from 'ethers';
+import { web3Erc20Contract } from 'lib/contracts';
+
+type AllowParams = {
+  callback: () => void;
+  contractAddress: string;
+  setTxHash: (value: string) => void;
+  setWaitingForTx: (value: boolean) => void;
+};
+export async function authorizeCurrency({
+  callback,
+  contractAddress,
+  setTxHash,
+  setWaitingForTx,
+}: AllowParams) {
+  const contract = web3Erc20Contract(contractAddress);
+  const t = await contract.approve(
+    process.env.NEXT_PUBLIC_NFT_LOAN_FACILITATOR_CONTRACT || '',
+    ethers.BigNumber.from(2).pow(256).sub(1),
+  );
+  setWaitingForTx(true);
+  setTxHash(t.hash);
+  t.wait()
+    .then(() => {
+      callback();
+      setWaitingForTx(false);
+    })
+    .catch((err) => {
+      setWaitingForTx(false);
+      console.log(err);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",
+    "@testing-library/user-event": "^13.5.0",
     "@typechain/ethers-v5": "^7.2.0",
     "@types/lodash": "^4.14.176",
     "@types/node": "^14.14.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3924,6 +3924,13 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
 
+"@testing-library/user-event@^13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
+  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
this PR gets us to 100% coverage on the Button and AllowButton components.

```
-----------------------------------------|---------|----------|---------|---------|-------------------
File                                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------------------|---------|----------|---------|---------|-------------------     
 components/Button                       |   66.66 |    73.68 |      80 |   65.51 |                   
  AllowButton.tsx                        |     100 |      100 |     100 |     100 |                   
  Button.tsx                             |     100 |      100 |     100 |     100 |                   
  ButtonLink.tsx                         |       0 |      100 |       0 |       0 | 11-12             
  CompletedButton.tsx                    |     100 |       80 |     100 |     100 | 15                
  TransactionButton.tsx                  |   55.55 |       60 |     100 |   55.55 | 26,32-38          
  WalletButton.tsx                       |   33.33 |      100 |       0 |   33.33 | 27-30 
```