### PR TITLE
chore: fix flaky CollateralInfo test

### DIFF
--- a/__tests__/components/CollateralInfo.test.tsx
+++ b/__tests__/components/CollateralInfo.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { CollateralInfo } from 'components/CollateralInfo';
 import {
-  CollectionStatistics,
   getFakeFloor,
   getFakeItemsAndOwners,
   getFakeVolume,
@@ -13,56 +12,45 @@ import { baseLoan } from 'lib/mockData';
 
 const loan = baseLoan;
 
+const floor = 17;
+const volume = 2;
+const items = 9999;
+const owners = 9000;
+const collectionStats = {
+  floor,
+  items,
+  owners,
+  volume,
+};
+
+const recentSale = generateFakeSaleForNFT(
+  baseLoan.collateralContractAddress,
+  baseLoan.collateralTokenId.toString(),
+);
+
+const saleInfo: CollateralSaleInfo = {
+  recentSale,
+  collectionStats,
+};
+
 describe('CollateralInfo', () => {
-  const getCollateralSaleInfo = (): CollateralSaleInfo => {
-    const [items, owners] = getFakeItemsAndOwners();
-    const floor = getFakeFloor();
-
-    // make sure randomly generated floor and volume are not equal, since this would cause
-    // getByText to fail, since this assertion expects exactly one node to have this text
-    let volume = getFakeVolume();
-    while (volume == floor) {
-      volume = getFakeVolume();
-    }
-
-    const collectionStats = {
-      floor,
-      items,
-      owners,
-      volume,
-    };
-
-    const recentSale = generateFakeSaleForNFT(
-      baseLoan.collateralContractAddress,
-      baseLoan.collateralTokenId.toString(),
-    );
-
-    return {
-      recentSale,
-      collectionStats,
-    };
-  };
-
   it('renders a Fieldset with a vertical description list with the right labels', () => {
-    const collateralSaleInfo = getCollateralSaleInfo();
     const { getByText } = render(
-      <CollateralInfo loan={loan} collateralSaleInfo={collateralSaleInfo} />,
+      <CollateralInfo loan={loan} collateralSaleInfo={saleInfo} />,
     );
 
     getByText('View on OpenSea');
     getByText("item's last sale");
-    getByText(
-      `${collateralSaleInfo.recentSale.price} ${collateralSaleInfo.recentSale.paymentToken}`,
-    );
+    getByText(`${recentSale.price} ${recentSale.paymentToken}`);
     getByText('collection');
     getByText(loan.collateralName);
     getByText('items');
-    getByText(collateralSaleInfo.collectionStats.items);
+    getByText(collectionStats.items);
     getByText('floor price');
-    getByText(`${collateralSaleInfo.collectionStats.floor} ETH`);
+    getByText(`${collectionStats.floor} ETH`);
     getByText('owners');
-    getByText(collateralSaleInfo.collectionStats.owners);
+    getByText(collectionStats.owners);
     getByText('volume');
-    getByText(`${collateralSaleInfo.collectionStats.volume} ETH`);
+    getByText(`${collectionStats.volume} ETH`);
   });
 });


### PR DESCRIPTION
Closes #384 
cnasc noticed this test was flaky due to the randomly generated `floor` and `volume` sometimes being equal. This PR fixes this by always ensuring they're different.