### PR TITLE
fix: set visibility on form open/close

### DIFF
--- a/components/AdvancedSearch/AdvancedSearch.module.css
+++ b/components/AdvancedSearch/AdvancedSearch.module.css
@@ -34,8 +34,9 @@
   padding-top: var(--gap);
   transition-timing-function: cubic-bezier(0.895, 0.03, 0.685, 0.22);
   transition-duration: 300ms;
-  transition-property: max-height, padding;
+  transition-property: max-height, padding, visibility;
   max-height: 2000px;
+  visibility: visible;
 }
 
 .searchClosed {
@@ -44,7 +45,8 @@
   overflow: hidden;
   text-transform: cubic-bezier(0.95, 0.05, 0.795, 0.035);
   transition-duration: 300ms;
-  transition-property: max-height, padding;
+  transition-property: max-height, padding, visibility;
+  visibility: hidden;
 }
 
 .inputGroupWrapperOpen {


### PR DESCRIPTION
fixes #386 

Setting this CSS property allows browsers to skip focusing it with keyboard.