### PR TITLE
fix: only shimmer when NFT image is loading

### DIFF
--- a/components/Media/NFTMedia.tsx
+++ b/components/Media/NFTMedia.tsx
@@ -36,7 +36,7 @@ export function NFTMedia({
   }, [load]);
 
   if (!nftInfo) {
-    return <Fallback small={small} />;
+    return <Fallback small={small} animated={collateralAddress.length > 0} />;
   }
 
   return (


### PR DESCRIPTION
On create page, fallback image only starts shimmering when we have already selected an NFT