### PR TITLE
fix: prevent LastPass from injecting icon into inputs

### DIFF
--- a/components/Form/Form.tsx
+++ b/components/Form/Form.tsx
@@ -3,10 +3,11 @@ import styles from './Form.module.css';
 
 export function Form({
   children,
+  autoComplete = 'off',
   ...props
 }: FormHTMLAttributes<HTMLFormElement>) {
   return (
-    <form className={styles.form} {...props}>
+    <form className={styles.form} autoComplete={autoComplete} {...props}>
       {children}
     </form>
   );

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -5,21 +5,34 @@ import styles from './Input.module.css';
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   color?: 'light' | 'dark';
   unit?: string;
+  ignoreLastPass?: boolean;
 }
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ color = 'light', unit, ...props }, ref) => {
+  ({ color = 'light', ignoreLastPass = true, unit, ...props }, ref) => {
     const className = unit ? styles[`${color}-unit`] : styles[color];
 
     if (unit) {
       return (
         <div className={styles.wrapper}>
-          <input className={className} {...props} ref={ref} />
+          <input
+            className={className}
+            {...props}
+            ref={ref}
+            data-lpignore={ignoreLastPass}
+          />
           <span className={styles.unit}>{unit}</span>
         </div>
       );
     }
-    return <input className={className} {...props} ref={ref} />;
+    return (
+      <input
+        className={className}
+        {...props}
+        ref={ref}
+        data-lpignore={ignoreLastPass}
+      />
+    );
   },
 );
 Input.displayName = 'Input';

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import ReactSelect, { GroupBase, Props } from 'react-select';
+import ReactSelect, { components, GroupBase, Props } from 'react-select';
 
 interface SelectProps<
   Option,
@@ -8,6 +8,10 @@ interface SelectProps<
 > extends Props<Option, IsMulti, Group> {
   color?: 'dark' | 'light';
 }
+
+const Input: typeof components.Input = (props) => {
+  return <components.Input {...props} data-lpignore />;
+};
 
 export function Select<
   Option,
@@ -89,6 +93,7 @@ export function Select<
       }}
       defaultValue={defaultValue}
       isClearable={isClearable}
+      components={{ Input }}
       {...props}
     />
   );


### PR DESCRIPTION
Apparently the attribute `data-lpignore` on an input will stop LastPass from injecting its icon. Let's give it a try.