### PR TITLE
nft-125: user notifications API should take loan

### DIFF
--- a/lib/events/consumers/userNotifications/shared.ts
+++ b/lib/events/consumers/userNotifications/shared.ts
@@ -1,11 +1,11 @@
-import { EventAsStringType } from 'types/Event';
+import { RawEventNameType } from 'types/RawEvent';
 
 export enum NotificationMethod {
   EMAIL = 'email',
 }
 
 export type NotificationTriggerType =
-  | EventAsStringType
+  | RawEventNameType
   | 'LiquidationOccurringBorrower'
   | 'LiquidationOccurringLender'
   | 'LiquidationOccurredBorrower'

--- a/lib/events/sqs/helpers.ts
+++ b/lib/events/sqs/helpers.ts
@@ -1,5 +1,5 @@
 import { SQS } from 'aws-sdk';
-import { EventAsStringType } from 'types/Event';
+import { RawEventNameType } from 'types/RawEvent';
 
 const sqsConfig = {
   region: 'us-east-1',
@@ -10,7 +10,7 @@ const sqsConfig = {
 };
 
 export type FormattedNotificationEventMessageType = {
-  eventName: EventAsStringType;
+  eventName: RawEventNameType;
   txHash: string;
   receiptHandle: string;
 };
@@ -23,7 +23,7 @@ export async function receiveMessages(): Promise<
 
   const response = await sqs.receiveMessage({ QueueUrl: queueUrl }).promise();
   return response.Messages?.map((message) => {
-    const messageBody: { txHash: string; eventName: EventAsStringType } =
+    const messageBody: { txHash: string; eventName: RawEventNameType } =
       JSON.parse(message.Body!);
     return {
       ...messageBody,

--- a/lib/eventsHelpers.ts
+++ b/lib/eventsHelpers.ts
@@ -13,10 +13,10 @@ import {
   RepaymentEventByTransactionHashDocument,
   RepaymentEventByTransactionHashQuery,
 } from 'types/generated/graphql/nftLoans';
-import { EventAsStringType } from 'types/Event';
+import { RawEventNameType } from 'types/RawEvent';
 
 export async function subgraphEventFromTxHash(
-  eventName: EventAsStringType,
+  eventName: RawEventNameType,
   txHash: string,
 ): Promise<
   | BuyoutEvent

--- a/pages/api/events/cron/processTimelyEvents.ts
+++ b/pages/api/events/cron/processTimelyEvents.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getNotificationRequestsForAddress } from 'lib/events/consumers/userNotifications/repository';
-import { sendEmail } from 'lib/events/consumers/userNotifications/emails';
+import { sendEmailsForTriggerAndLoan } from 'lib/events/consumers/userNotifications/emails';
 import { NotificationTriggerType } from 'lib/events/consumers/userNotifications/shared';
 import { Loan } from 'types/generated/graphql/nftLoans';
 import { NotificationRequest } from '@prisma/client';
@@ -30,33 +30,10 @@ export default async function handler(
       loanIndex++
     ) {
       const loan = liquidationOccurringLoans[loanIndex];
-      const notificationRequestsBorrower =
-        await getNotificationRequestsForAddress(loan.borrowTicketHolder);
-      for (
-        let notificationIndex = 0;
-        notificationIndex < notificationRequestsBorrower.length;
-        notificationIndex++
-      ) {
-        await sendEmail(
-          notificationRequestsBorrower[notificationIndex].deliveryDestination,
-          'LiquidationOccurringBorrower',
-          loan,
-        );
-      }
 
-      const notificationRequestsLender =
-        await getNotificationRequestsForAddress(loan.lendTicketHolder);
-      for (
-        let notificationIndex = 0;
-        notificationIndex < notificationRequestsBorrower.length;
-        notificationIndex++
-      ) {
-        await sendEmail(
-          notificationRequestsLender[notificationIndex].deliveryDestination,
-          'LiquidationOccurringLender',
-          loan,
-        );
-      }
+      await sendEmailsForTriggerAndLoan('LiquidationOccurringBorrower', loan);
+
+      await sendEmailsForTriggerAndLoan('LiquidationOccurringLender', loan);
     }
 
     for (
@@ -65,33 +42,10 @@ export default async function handler(
       loanIndex++
     ) {
       const loan = liquidationOccurredLoans[loanIndex];
-      const notificationRequestsBorrower =
-        await getNotificationRequestsForAddress(loan.borrowTicketHolder);
-      for (
-        let notificationIndex = 0;
-        notificationIndex < notificationRequestsBorrower.length;
-        notificationIndex++
-      ) {
-        await sendEmail(
-          notificationRequestsBorrower[notificationIndex].deliveryDestination,
-          'LiquidationOccurredBorrower',
-          loan,
-        );
-      }
 
-      const notificationRequestsLender =
-        await getNotificationRequestsForAddress(loan.lendTicketHolder);
-      for (
-        let notificationIndex = 0;
-        notificationIndex < notificationRequestsBorrower.length;
-        notificationIndex++
-      ) {
-        await sendEmail(
-          notificationRequestsLender[notificationIndex].deliveryDestination,
-          'LiquidationOccurredLender',
-          loan,
-        );
-      }
+      await sendEmailsForTriggerAndLoan('LiquidationOccurredBorrower', loan);
+
+      await sendEmailsForTriggerAndLoan('LiquidationOccurredLender', loan);
     }
 
     res.status(200).json(`notifications successfully sent`);

--- a/types/Event.ts
+++ b/types/Event.ts
@@ -54,11 +54,3 @@ export type Event =
   | CreateEvent
   | LendEvent
   | RepaymentEvent;
-
-export type EventAsStringType =
-  | 'BuyoutEvent'
-  | 'CloseEvent'
-  | 'CollateralSeizureEvent'
-  | 'CreateEvent'
-  | 'LendEvent'
-  | 'RepaymentEvent';

--- a/types/RawEvent.ts
+++ b/types/RawEvent.ts
@@ -1,0 +1,24 @@
+import {
+  BuyoutEvent,
+  CloseEvent,
+  CollateralSeizureEvent,
+  CreateEvent,
+  LendEvent,
+  RepaymentEvent,
+} from './generated/graphql/nftLoans';
+
+export type RawSubgraphEvent =
+  | BuyoutEvent
+  | CloseEvent
+  | CollateralSeizureEvent
+  | CreateEvent
+  | LendEvent
+  | RepaymentEvent;
+
+export type RawEventNameType =
+  | 'BuyoutEvent'
+  | 'CloseEvent'
+  | 'CollateralSeizureEvent'
+  | 'CreateEvent'
+  | 'LendEvent'
+  | 'RepaymentEvent';


### PR DESCRIPTION
This PR refactors the way we send emails, as well as ensures that all user notification based APIs take just a loan and evente name as input to the body. 

We also move the logic of getting which users to send emails too outside of the API handler and to the lib function to make the API more lightweight.