### PR TITLE
nft-135: modify liquidation cron to run every hour

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -17,5 +17,5 @@ NEXT_PUBLIC_NFT_PORT_API_KEY="nft-port-api-key-here"
 NEXT_PUBLIC_NOTIFICATION_REQ_MESSAGE="signing notification request"
 DATABASE_URL="postgresql://user:password@localhost:5432/notifications?schema=public"
 NEXT_PUBLIC_PAWN_SHOP_API_URL="https://nft-pawn-shop-rinkeby.vercel.app"
-NEXT_PUBLIC_NOTIFICATIONS_FREQUENCY_HOURS=12
+NEXT_PUBLIC_NOTIFICATIONS_FREQUENCY_HOURS=1
 EVENTS_API_SECRET_KEY="very secret key"

--- a/__tests__/lib/events/timely/timely.test.ts
+++ b/__tests__/lib/events/timely/timely.test.ts
@@ -9,11 +9,7 @@ import {
 } from 'lib/events/consumers/userNotifications/repository';
 
 let lastRun = 1645155901;
-let now =
-  lastRun +
-  parseInt(process.env.NEXT_PUBLIC_NOTIFICATIONS_FREQUENCY_HOURS!) * 3600;
-const future =
-  now + parseInt(process.env.NEXT_PUBLIC_NOTIFICATIONS_FREQUENCY_HOURS!) * 3600;
+let now = lastRun + 3600;
 
 const aboutToExpireLoan = {
   ...subgraphLoan,
@@ -69,8 +65,11 @@ describe('getLiquidatedLoansForTimestamp', () => {
       await getLiquidatedLoansForTimestamp(now);
 
     expect(mockedGetExpiringLoansCall).toHaveBeenCalledTimes(2);
-    expect(mockedGetExpiringLoansCall).toHaveBeenCalledWith(now, future);
-    expect(mockedGetExpiringLoansCall).toHaveBeenCalledWith(lastRun, now);
+    expect(mockedGetExpiringLoansCall).toHaveBeenCalledWith(
+      now + 25 * 3600,
+      now + 24 * 3600,
+    );
+    expect(mockedGetExpiringLoansCall).toHaveBeenCalledWith(now - 3600, now);
 
     expect(liquidationOccurringLoans).toEqual([aboutToExpireLoan]);
     expect(liquidationOccurredLoans).toEqual([alreadyExpiredLoan]);

--- a/lib/events/timely/timely.ts
+++ b/lib/events/timely/timely.ts
@@ -5,6 +5,8 @@ import {
   overrideLastWrittenTimestamp,
 } from '../consumers/userNotifications/repository';
 
+const HOURS_IN_DAY = 24;
+
 type LiquidatedLoans = {
   liquidationOccurringLoans: Loan[];
   liquidationOccurredLoans: Loan[];
@@ -13,7 +15,11 @@ type LiquidatedLoans = {
 export async function getLiquidatedLoansForTimestamp(
   currentTimestamp: number,
 ): Promise<LiquidatedLoans> {
-  if (process.env.NEXT_PUBLIC_NOTIFICATIONS_KILLSWITCH)
+  const notificationsFreq = parseInt(
+    process.env.NEXT_PUBLIC_NOTIFICATIONS_FREQUENCY_HOURS!,
+  );
+
+  if (process.env.NEXT_PUBLIC_NOTIFICATIONS_KILLSWITCH || !notificationsFreq)
     return {
       liquidationOccurredLoans: [],
       liquidationOccurringLoans: [],
@@ -22,23 +28,21 @@ export async function getLiquidatedLoansForTimestamp(
   let pastTimestamp = await getLastWrittenTimestamp();
   if (!pastTimestamp) {
     // if we couldn't get pastTimestamp from postgres for whatever reason, just default to N hours before
-    pastTimestamp =
-      currentTimestamp -
-      parseInt(process.env.NEXT_PUBLIC_NOTIFICATIONS_FREQUENCY_HOURS!) * 3600;
+    pastTimestamp = currentTimestamp - notificationsFreq * 3600;
   }
 
-  const futureTimestamp =
-    currentTimestamp +
-    parseInt(process.env.NEXT_PUBLIC_NOTIFICATIONS_FREQUENCY_HOURS!) * 3600;
+  // ensure no timestamps get missed by using the last run timestamp + 1 hour (or whatever of freq is)
+  // in a perfect world, currentTimestamp === currentRunTimestamp, but with inconsistincies in our cron or anything else, they may differ
+  const currentRunTimestamp = pastTimestamp + notificationsFreq * 3600;
 
   const liquidationOccurringLoans = await getLoansExpiringWithin(
-    currentTimestamp,
-    futureTimestamp,
+    currentRunTimestamp + (HOURS_IN_DAY + notificationsFreq) * 3600,
+    currentRunTimestamp + HOURS_IN_DAY * 3600,
   );
 
   const liquidationOccurredLoans = await getLoansExpiringWithin(
-    pastTimestamp,
-    currentTimestamp,
+    currentRunTimestamp - notificationsFreq * 3600,
+    currentRunTimestamp,
   );
 
   await overrideLastWrittenTimestamp(currentTimestamp);


### PR DESCRIPTION
Run liquidations emails cron every hour, checking for loans expiring within 25 hours and 24 hours from now to guarantee user gets at least 24 hour notice