### PR TITLE
fix: don't use AbortController

### DIFF
--- a/pages/api/nftInfo/[uri].ts
+++ b/pages/api/nftInfo/[uri].ts
@@ -21,7 +21,7 @@ export default async function handler(
     const { uri } = req.query;
     const decodedUri = decodeURIComponent(uri as string);
     const resolvedUri = convertIPFS(decodedUri);
-    const tokenURIRes = await fetchWithTimeout(resolvedUri);
+    const tokenURIRes = await fetch(resolvedUri);
     const { name, description, tokenId, image, animation_url, external_url } =
       await tokenURIRes.json();
     res.status(200).json({


### PR DESCRIPTION
Looks like when we deploy to Vercel it uses a version of node that doesn't have AbortController, causing a runtime error on the api route. Quick fix is to fall back to vanilla fetch. Works locally, presumably because I'm using a recent version of node