### PR TITLE
NFT-145 css: typography wrangling

### DIFF
--- a/components/Toggle/Toggle.module.css
+++ b/components/Toggle/Toggle.module.css
@@ -17,6 +17,7 @@
   padding: 0.5rem 1rem;
   border-radius: var(--border-radius-large);
   color: var(--neutral-50);
+  font-size: var(--font-large);
 }
 
 .left {

--- a/styles/global.css
+++ b/styles/global.css
@@ -58,9 +58,9 @@
   --weight-light: 300;
   --weight-regular: 400;
   --weight-semibold: 600;
-  --font-small: 0.715rem;
-  --font-medium: 1.125rem;
-  --font-large: 1.43rem;
+  --font-small: 12px;
+  --font-medium: 15px;
+  --font-large: 18px;
   --font-huge: 2.6rem;
 
   /* component specific dimensions */
@@ -74,7 +74,7 @@ html,
 body {
   font-family: var(--mono);
   line-height: var(--line-height);
-  font-size: 14px;
+  font-size: var(--font-medium);
   font-weight: var(--weight-regular);
   background: var(--background-white);
   min-height: 100vh;


### PR DESCRIPTION
All font-size declarations use the defined variables (one special case for the emoji in the media fallback).
Set the vars according to the linear issue, and ensured that button and toggles use large text.