### PR TITLE
fix: animation_url can be empty string

### DIFF
--- a/lib/getNFTInfo.ts
+++ b/lib/getNFTInfo.ts
@@ -48,7 +48,7 @@ export async function getNFTInfoFromTokenInfo(
     }
 
     const mediaUrl =
-      NFTInfo.animation_url == null || forceImage
+      !NFTInfo.animation_url || forceImage
         ? NFTInfo.image
         : NFTInfo.animation_url;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/161787599-323181f7-14b6-4ded-82cb-6a6b3d2bdc6b.png)

Issue here is that the NFT in question had the empty string as its `animation_url` and our code only explicitly looked for null instead of falsy values.