### PR TITLE
fix: remove stray semicolon

### DIFF
--- a/pages/loans/create.tsx
+++ b/pages/loans/create.tsx
@@ -14,7 +14,7 @@ export default function Create() {
         />
       </Head>
       <PawnShopHeader />
-      <CreatePageHeader />;
+      <CreatePageHeader />
     </>
   );
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/162995400-a079503d-97e5-4550-8277-7c4e09a7c8f2.png)

The 404/500 PR accidentally introduced a semicolon in JSX that would render on the page. This PR removes it. We should see if there's a lint rule that can catch this.