### PR TITLE
chore: PAGE_LIMIT divisible by 3

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,7 @@ import { HomePageLoans } from 'components/HomePageLoans';
 import { PawnShopHeader } from 'components/PawnShopHeader';
 import Head from 'next/head';
 
-const PAGE_LIMIT = 20;
+const PAGE_LIMIT = 18;
 
 export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
   return {


### PR DESCRIPTION
this just fixes a mild annoyance, we used to load 20 at a time but since we show 3 in a row by default the last row wouldn't be even