### PR TITLE
trivial: fix liquidation emails fetch

### DIFF
--- a/lib/loans/subgraph/subgraphLoans.ts
+++ b/lib/loans/subgraph/subgraphLoans.ts
@@ -143,7 +143,6 @@ export async function getLoansExpiringWithin(
   timeOne: number,
   timeTwo: number,
 ): Promise<Loan[]> {
-  console.log({ timeOne, timeTwo });
   const where: Loan_Filter = {
     endDateTimestamp_gt: timeOne,
     endDateTimestamp_lt: timeTwo,

--- a/pages/api/events/cron/processTimelyEvents.ts
+++ b/pages/api/events/cron/processTimelyEvents.ts
@@ -18,8 +18,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse<string>) {
     const { liquidationOccurringLoans, liquidationOccurredLoans } =
       await getLiquidatedLoansForTimestamp(currentTimestamp);
 
-    console.log({ liquidationOccurringLoans, liquidationOccurredLoans });
-
     for (
       let loanIndex = 0;
       loanIndex < liquidationOccurringLoans.length;


### PR DESCRIPTION
had the greater than and less than timestamp flipped