### PR TITLE
fix: avoid loading ticket art for now

### DIFF
--- a/components/PawnArt/PawnArt.tsx
+++ b/components/PawnArt/PawnArt.tsx
@@ -44,7 +44,7 @@ function PawnArt({ contract, tokenID }: PawnArtProps) {
   const { isLoading, metadata } = useTokenMetadata(tokenSpec);
 
   useEffect(() => {
-    contract.tokenURI(tokenID).then(setTokenURI);
+    // contract.tokenURI(tokenID).then(setTokenURI);
   }, [contract, tokenID]);
 
   if (isLoading || !metadata) {


### PR DESCRIPTION
unbreaks loan pages while we wait for new contracts to deploy