### PR TITLE
Update Fieldset.module.css

### DIFF
--- a/components/Fieldset/Fieldset.module.css
+++ b/components/Fieldset/Fieldset.module.css
@@ -3,7 +3,8 @@
   background: var(--background-fieldset);
   width: 100%;
   padding: var(--padding-container);
-  word-break: break-all;
+  word-break: normal;
+  overflow-wrap: anywhere;
 }
 
 .legend {


### PR DESCRIPTION
We added 'word-break: break-all' earlier so that long NFT titles didn't break the "Collateral" section layout. Unfortunately this was *too much breaking* and now we have labels (ex. PAYBACK AT MATURITY) that break in the middle of words (viz. PAYBACK AT MAT      URITY). The correct CSS for what we want is `break-word` but that has been deprecated in favor of 'word- break: normal;' combined with 'overflow-wrap: anywhere'. This PR adds that to our fieldset module.

See: in *Collateral* the long title wraps by splitting characters and in *Repayment* "Payback at Maturity" splits by breaking words
![image](https://user-images.githubusercontent.com/971753/164506679-3bfef116-4fd1-435c-bb88-bc553fc93d85.png)
