### PR TITLE
trivial: fix nft sale info page

### DIFF
--- a/__tests__/components/CollateralInfo.test.tsx
+++ b/__tests__/components/CollateralInfo.test.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { CollateralInfo } from 'components/CollateralInfo';
-import {
-  getFakeFloor,
-  getFakeItemsAndOwners,
-  getFakeVolume,
-} from 'lib/nftPort';
 import { CollateralSaleInfo } from 'lib/loans/collateralSaleInfo';
 import { generateFakeSaleForNFT } from 'lib/nftSalesSubgraph';
 import { baseLoan } from 'lib/mockData';
@@ -54,9 +49,15 @@ describe('CollateralInfo', () => {
     getByText(`${collectionStats.volume} ETH`);
   });
 
-  it('renders a Fieldset with a message when there is no collateral info', () => {
+  it('renders a Fieldset with a message when there is no recent sale info', () => {
     const { getByText } = render(
-      <CollateralInfo loan={loan} collateralSaleInfo={null} />,
+      <CollateralInfo
+        loan={loan}
+        collateralSaleInfo={{
+          collectionStats,
+          recentSale: null,
+        }}
+      />,
     );
 
     getByText('No recent sale info');

--- a/components/CollateralInfo/CollateralInfo.tsx
+++ b/components/CollateralInfo/CollateralInfo.tsx
@@ -8,7 +8,7 @@ import styles from './CollateralInfo.module.css';
 
 type CollateralInfoProps = {
   loan: Loan;
-  collateralSaleInfo: CollateralSaleInfo;
+  collateralSaleInfo: CollateralSaleInfo | null;
 };
 
 export const CollateralInfo = ({

--- a/lib/nftSalesSubgraph.ts
+++ b/lib/nftSalesSubgraph.ts
@@ -41,7 +41,7 @@ const NFT_EXCHANGES = {
   '0xE7dd1252f50B3d845590Da0c5eADd985049a03ce': 'Zora',
 };
 
-const PAYMENT_TOKENS = {
+const PAYMENT_TOKENS: any = {
   '0xc778417e063141139fce010982780140aa0cd5ab': 'WETH',
   '0x6916577695D0774171De3ED95d03A3239139Eddb': 'DAI',
 };
@@ -61,7 +61,7 @@ export const generateFakeSaleForNFT = (
 ): NFTSale => {
   return {
     id: genRanHex(),
-    blockNumber: ethers.BigNumber.from(randomNumber(1000000)),
+    blockNumber: ethers.BigNumber.from(randomNumber(1000000)).toString(),
     buyer: genRanHex(),
     seller: genRanHex(),
     nftContractAddress,


### PR DESCRIPTION
We were prematurely returning if we did not get a sale info. We should keep the function running to get NFT Port collection stats even if item did not have a recent sale.