### PR TITLE
[wip] feat: compliance/terms modal

### DIFF
--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -5,12 +5,14 @@ import React, { FunctionComponent } from 'react';
 type ModalProps = {
   dialog: DialogStateReturn;
   heading?: string;
+  allowHide?: boolean;
   width?: 'regular' | 'narrow';
 };
 export const Modal: FunctionComponent<ModalProps> = ({
   children,
   dialog,
   heading,
+  allowHide = true,
   width = 'regular',
 }) => {
   return (
@@ -18,6 +20,8 @@ export const Modal: FunctionComponent<ModalProps> = ({
       tabIndex={0}
       aria-label={!!heading ? heading : ''}
       className={`${styles.dialog} ${styles[width]}`}
+      hideOnClickOutside={allowHide}
+      hideOnEsc={allowHide}
       {...dialog}
       modal={false}>
       {Boolean(heading) && <h3 className={styles.heading}>{heading}</h3>}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -12,3 +12,5 @@ export const SCALAR = ethers.BigNumber.from(10).pow(
 export const DISCORD_URL = 'https://discord.gg/ZCxGuE6Ytk';
 export const TWITTER_URL = 'https://twitter.com/backed_xyz';
 export const GITHUB_URL = 'https://github.com/with-backed';
+
+export const LS_TERMS_AGREEMENT = 'backed/user-has-viewed-terms';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,6 +18,11 @@ import { WagmiProvider, chain } from 'wagmi';
 import { CachedRatesProvider } from 'hooks/useCachedRates/useCachedRates';
 import { HasCollapsedHeaderInfoProvider } from 'hooks/useHasCollapsedHeaderInfo';
 import { Footer } from 'components/Footer';
+import { useDialogState } from 'reakit/Dialog';
+import { Modal } from 'components/Modal';
+import { useCallback, useEffect } from 'react';
+import { Button } from 'components/Button';
+import { LS_TERMS_AGREEMENT } from 'lib/constants';
 
 const jsonRpcProvider = new providers.JsonRpcProvider(
   process.env.NEXT_PUBLIC_JSON_RPC_PROVIDER,
@@ -38,6 +43,19 @@ const connectors = connectorsForWallets(wallets)({
 });
 
 export default function App({ Component, pageProps }: AppProps) {
+  const dialog = useDialogState();
+
+  const agree = useCallback(() => {
+    localStorage.setItem(LS_TERMS_AGREEMENT, 'yes');
+    dialog.hide();
+  }, [dialog]);
+
+  useEffect(() => {
+    const userHasAgreed = localStorage.getItem(LS_TERMS_AGREEMENT);
+    if (!userHasAgreed) {
+      dialog.show();
+    }
+  }, [dialog]);
   return (
     <GlobalMessagingProvider>
       <RainbowKitProvider theme={lightTheme()} chains={chains}>
@@ -50,6 +68,10 @@ export default function App({ Component, pageProps }: AppProps) {
               <HasCollapsedHeaderInfoProvider>
                 <AppWrapper>
                   <Component {...pageProps} />
+                  <Modal allowHide={false} dialog={dialog}>
+                    enforcement check
+                    <Button onClick={agree}>You got it, chief</Button>
+                  </Modal>
                   <Footer />
                 </AppWrapper>
               </HasCollapsedHeaderInfoProvider>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/164807980-099f0b03-57dd-43d2-8a80-cad5089cf214.png)

Obviously exact wording TBD, but this will pop up the modal on each visit if the user hasn't agreed to the terms. This is judged by the presence of a value in localStorage. 