### PR TITLE
fix: get tokenURI by collateralTokenId

### DIFF
--- a/lib/loans/node/nodeLoanById.ts
+++ b/lib/loans/node/nodeLoanById.ts
@@ -46,7 +46,9 @@ export async function nodeLoanById(loanId: string): Promise<Loan> {
   const collateralAssetContract = jsonRpcERC721Contract(
     collateralContractAddress,
   );
-  const collateralTokenURI = await collateralAssetContract.tokenURI(id);
+  const collateralTokenURI = await collateralAssetContract.tokenURI(
+    collateralTokenId,
+  );
   const collateralName = await collateralAssetContract.name();
 
   return {


### PR DESCRIPTION
When getting the loan from the node, this caused us to load the wrong tokenURI (and sometimes an invalid tokenURI); this was reported in Discord when a user noticed briefly seeing the wrong token art on their loan.