### PR TITLE
fix: handle undefined in nftPort response

### DIFF
--- a/components/CollateralInfo/CollateralInfo.tsx
+++ b/components/CollateralInfo/CollateralInfo.tsx
@@ -68,22 +68,24 @@ export const CollateralInfo = ({
 
         <div className={styles.collectionInfoElement}>
           <dt className={styles.label}>items</dt>
-          <dd>{collateralSaleInfo.collectionStats.items}</dd>
+          <dd>{collateralSaleInfo.collectionStats.items || '--'}</dd>
         </div>
 
         <div className={styles.collectionInfoElement}>
           <dt className={styles.label}>floor price</dt>
-          <dd>{collateralSaleInfo.collectionStats.floor} ETH</dd>
+          <dd>{collateralSaleInfo.collectionStats.floor || '--'} ETH</dd>
         </div>
 
         <div className={styles.collectionInfoElement}>
           <dt className={styles.label}>owners</dt>
-          <dd>{collateralSaleInfo.collectionStats.owners}</dd>
+          <dd>{collateralSaleInfo.collectionStats.owners || '--'}</dd>
         </div>
 
         <div className={styles.collectionInfoElement}>
           <dt className={styles.label}>volume</dt>
-          <dd>{collateralSaleInfo.collectionStats.volume.toFixed(4)} ETH</dd>
+          <dd>
+            {collateralSaleInfo.collectionStats.volume?.toFixed(4) || '--'} ETH
+          </dd>
         </div>
       </DescriptionList>
     </Fieldset>

--- a/lib/nftPort.ts
+++ b/lib/nftPort.ts
@@ -1,8 +1,8 @@
 export type CollectionStatistics = {
-  floor: number;
-  items: number;
-  owners: number;
-  volume: number;
+  floor: number | null;
+  items: number | null;
+  owners: number | null;
+  volume: number | null;
 };
 
 export async function collectionStats(
@@ -22,10 +22,10 @@ export async function collectionStats(
   const statsResJson: any = await statsRes.json();
 
   return {
-    floor: statsResJson.statistics?.floor_price,
-    items: statsResJson.statistics?.total_supply,
-    owners: statsResJson.statistics?.num_owners,
-    volume: statsResJson.statistics?.total_volume,
+    floor: statsResJson.statistics?.floor_price || null,
+    items: statsResJson.statistics?.total_supply || null,
+    owners: statsResJson.statistics?.num_owners || null,
+    volume: statsResJson.statistics?.total_volume || null,
   };
 }
 


### PR DESCRIPTION
In prod there's a 500 error when loading `/loans/21`.

Here's the error I see locally:
![image](https://user-images.githubusercontent.com/9300702/165096521-181f4b8c-fc37-46f5-b668-842a1a93b716.png)

Guessing NFTPort doesn't have info for this one, and we're assuming we'll always get a number back from the api. Making it more explicit that we may not get data, and handling on frontend. It'll render like this when we don't have the data:

![image](https://user-images.githubusercontent.com/9300702/165096728-af5e44d6-b56f-4042-aae4-e02a6e4e7aa4.png)
