### PR TITLE
chore: default wallet list sorted alphabetically

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -33,6 +33,8 @@ const wallets = getDefaultWallets({
     chain.mainnet.rpcUrls[0],
 });
 
+wallets[0].wallets.sort((a, b) => a.id.localeCompare(b.id));
+
 const connectors = connectorsForWallets(wallets)({
   chainId: parseInt(process.env.NEXT_PUBLIC_CHAIN_ID || '1'),
 });


### PR DESCRIPTION
The default wallet option in the rainbowkit list is Rainbow (which is fair), though it was raised to us that Rainbow is a less common wallet than others, and users might expect to see a more familiar one at the top. In the interest of maintaining a simpler implementation (because the API for doing this is not stable) and to avoid any particular bias, this PR sorts the default list of wallets alphabetically. In the future we could weight each position by adoption percentage.

![image](https://user-images.githubusercontent.com/9300702/165132574-9ad71d39-0eab-489f-95c8-31b3c160e5c4.png)
