### PR TITLE
NFT-239 feat: nftInfo api provides media mime type

### DIFF
--- a/lib/events/consumers/discord/attachments.ts
+++ b/lib/events/consumers/discord/attachments.ts
@@ -13,8 +13,10 @@ export async function collateralToDiscordMessageEmbed(
   let rawBufferAttachment: MessageAttachment | undefined = undefined;
   let messageEmbed: MessageEmbed;
 
-  if (nftResponseData!.image.startsWith(SVG_PREFIX)) {
-    const pngBuffer = await getPngBufferFromBase64SVG(nftResponseData!.image);
+  if (nftResponseData?.image?.mediaUrl.startsWith(SVG_PREFIX)) {
+    const pngBuffer = await getPngBufferFromBase64SVG(
+      nftResponseData!.image!.mediaUrl,
+    );
 
     rawBufferAttachment = new MessageAttachment(
       Buffer.from(pngBuffer, 'base64'),
@@ -27,7 +29,7 @@ export async function collateralToDiscordMessageEmbed(
   } else {
     messageEmbed = new MessageEmbed()
       .setTitle(`${collateralName} #${collateralTokenId}`)
-      .setImage(nftResponseData!.image);
+      .setImage(nftResponseData!.image!.mediaUrl);
   }
 
   return messageEmbed;

--- a/lib/events/consumers/twitter/attachments.ts
+++ b/lib/events/consumers/twitter/attachments.ts
@@ -7,10 +7,10 @@ const SVG_PREFIX = 'data:image/svg+xml;base64,';
 export async function nftResponseDataToImageBuffer(
   nftResponseData: NFTResponseData,
 ): Promise<string | undefined> {
-  if (nftResponseData!.image.startsWith(SVG_PREFIX)) {
-    return await getPngBufferFromBase64SVG(nftResponseData!.image);
+  if (nftResponseData?.image?.mediaUrl.startsWith(SVG_PREFIX)) {
+    return await getPngBufferFromBase64SVG(nftResponseData!.image!.mediaUrl);
   } else {
-    const imageUrlRes = await fetch(nftResponseData!.image);
+    const imageUrlRes = await fetch(nftResponseData!.image!.mediaUrl);
     const arraybuffer = await imageUrlRes.arrayBuffer();
     const outputBuffer = Buffer.from(arraybuffer);
     return outputBuffer.toString('base64');

--- a/lib/getNFTInfo.ts
+++ b/lib/getNFTInfo.ts
@@ -44,7 +44,7 @@ export async function getNFTInfoFromTokenInfo(
   }
 }
 
-async function getMimeType(mediaUrl: string) {
+export async function getMimeType(mediaUrl: string) {
   const defaultMimeType = 'application/octet-stream';
   try {
     const res = await fetch(mediaUrl, { method: 'HEAD' });
@@ -62,16 +62,15 @@ async function supportedMedia(
   nft: NFTResponseData,
   forceImage?: boolean,
 ): Promise<{ mediaUrl: string; mediaMimeType: string }> {
-  const { animation_url, image } = nft!;
+  const { animation, image } = nft!;
 
-  const [animationMimeType, imageMimeType] = await Promise.all([
-    getMimeType(animation_url || ''),
-    getMimeType(image || ''),
-  ]);
-
-  if (forceImage || !animation_url || animationMimeType.includes('text')) {
-    return { mediaUrl: image, mediaMimeType: imageMimeType };
+  if (!animation && !image) {
+    throw new Error(`No media associated with ${nft?.name}`);
   }
 
-  return { mediaUrl: animation_url, mediaMimeType: animationMimeType };
+  if (forceImage || !animation || animation.mediaMimeType.includes('text')) {
+    return image!;
+  }
+
+  return animation!;
 }


### PR DESCRIPTION
This clears up some CORS noise we got on the client side; also makes sure we accurately detect things because the client-side HEAD request was guaranteed to fail.

![image](https://user-images.githubusercontent.com/9300702/165354741-ae374b08-0887-40ee-b8c7-a39208428176.png)

e.g., this allows `/loans/11` to load 