### PR TITLE
fix: ignore non-resolveable cid

### DIFF
--- a/pages/api/nftInfo/[uri].ts
+++ b/pages/api/nftInfo/[uri].ts
@@ -51,6 +51,7 @@ async function handler(
         captureException(e);
       }
     }
+    // TODO: we could respond with a failure reason and surface that in the UI.
     return res.status(404).json(null);
   }
 }

--- a/pages/api/nftInfo/[uri].ts
+++ b/pages/api/nftInfo/[uri].ts
@@ -41,7 +41,16 @@ async function handler(
       external_url,
     });
   } catch (e) {
-    captureException(e);
+    if (e instanceof Error) {
+      if (
+        e.name === 'FetchError' &&
+        e.message.startsWith('invalid json response body')
+      ) {
+        // this happens when the root CID exists but the child file does not. No way to get the file, do nothing.
+      } else {
+        captureException(e);
+      }
+    }
     return res.status(404).json(null);
   }
 }


### PR DESCRIPTION
The largest group of errors we've logged to Sentry are [FetchError: invalid json response body at...](https://sentry.io/organizations/non-fungible-finance/issues/3210944660/?project=6318688) 

When we try to fetch some token metadata from IPFS instead of json we get back text that says something like:
```
ipfs resolve -r /ipfs/QmXuEFJVjQrHX7GRWY2WnbUP59re3WsyDLZoKqXvRPSxBY/1083: no link named "1083" under QmXuEFJVjQrHX7GRWY2WnbUP59re3WsyDLZoKqXvRPSxBY
 - The root CID exists but the child file does not. - ERR_ID:00020
```

These seem to entirely be on rinkeby, particularly for the Monarchs. For example, http://rinkeby.withbacked.xyz/loans/133 (see OpenSea link to confirm this is not on our end). This PR does not log these errors, as there isn't anything we can do about them.