### PR TITLE
chore: factor nftInfo methods into lib/

### DIFF
--- a/__tests__/components/LoanTickets.test.tsx
+++ b/__tests__/components/LoanTickets.test.tsx
@@ -14,6 +14,8 @@ jest.mock('lib/account', () => ({
   addressToENS: jest.fn(),
 }));
 
+jest.mock('lib/getNFTInfo');
+
 const mockAddressToENS = addressToENS as jest.MockedFunction<
   typeof addressToENS
 >;

--- a/__tests__/lib/getNFTInfo.test.ts
+++ b/__tests__/lib/getNFTInfo.test.ts
@@ -1,0 +1,109 @@
+import { convertIPFS, getMimeType, supportedMedia } from 'lib/getNFTInfo';
+import fetchMock from 'jest-fetch-mock';
+import { captureException } from '@sentry/nextjs';
+import { NFTResponseData } from 'pages/api/nftInfo/[uri]';
+
+jest.mock('@sentry/nextjs', () => ({
+  ...jest.requireActual('@sentry/nextjs'),
+  captureException: jest.fn(),
+}));
+
+describe('getNFTInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('getMimeType', () => {
+    let response: Response;
+    beforeEach(() => {
+      jest.clearAllMocks();
+      response = new Response();
+      fetchMock.mockResolvedValue(response);
+    });
+    it('returns Content-Type header, when present', async () => {
+      const expectedMimeType = 'audio/ogg';
+      response.headers.set('Content-Type', expectedMimeType);
+      const mimeType = await getMimeType('https://some-fake-url');
+
+      expect(mimeType).toEqual(expectedMimeType);
+      expect(captureException).not.toHaveBeenCalled();
+    });
+
+    it('returns default content-type, when Content-Type header not present', async () => {
+      const expectedMimeType = 'application/octet-stream';
+      const mimeType = await getMimeType('https://some-fake-url');
+
+      expect(mimeType).toEqual(expectedMimeType);
+      expect(captureException).not.toHaveBeenCalled();
+    });
+
+    it('returns default content-type and logs an error, when fetch fails', async () => {
+      const expectedMimeType = 'application/octet-stream';
+      fetchMock.mockRejectedValue('fail');
+      const mimeType = await getMimeType('https://some-fake-url');
+
+      expect(mimeType).toEqual(expectedMimeType);
+      expect(captureException).toHaveBeenCalledWith('fail');
+    });
+  });
+
+  describe('supportedMedia', () => {
+    const data: NFTResponseData = {
+      name: 'a token',
+      description: 'a token',
+      tokenId: 8,
+      external_url: 'https:some-fake-url',
+      image: null,
+      animation: null,
+    };
+    const image = { mediaUrl: 'image', mediaMimeType: 'image' };
+    const animation = { mediaUrl: 'animation', mediaMimeType: 'animation' };
+    it('throws when there is no associated media', () => {
+      expect(() => supportedMedia(data)).toThrow();
+    });
+
+    it('returns image when appropriate', () => {
+      expect(supportedMedia({ ...data, image, animation }, true)).toEqual(
+        image,
+      );
+      expect(
+        supportedMedia({ ...data, image, animation: null }, false),
+      ).toEqual(image);
+      expect(
+        supportedMedia(
+          {
+            ...data,
+            image,
+            animation: { ...animation, mediaMimeType: 'text/whatever' },
+          },
+          false,
+        ),
+      ).toEqual(image);
+    });
+
+    it('returns animation otherwise', () => {
+      expect(supportedMedia({ ...data, image, animation })).toEqual(animation);
+    });
+  });
+
+  describe('convertIPFS', () => {
+    it('returns undefined if uri is not defined', () => {
+      expect(convertIPFS()).toBeUndefined();
+    });
+
+    it('returns uri unchanged if it does not contain a cid', () => {
+      expect(convertIPFS('https://google.com')).toEqual('https://google.com');
+    });
+
+    it('captures an exception for unreadable input', () => {
+      // contains CID, but isn't actually a URL
+      expect(
+        convertIPFS('QmXuEFJVjQrHX7GRWY2WnbUP59re3WsyDLZoKqXvRPSxBY'),
+      ).toEqual('QmXuEFJVjQrHX7GRWY2WnbUP59re3WsyDLZoKqXvRPSxBY');
+      expect(captureException).toHaveBeenCalledWith(
+        new Error(
+          'unsupported URL pattern, please submit a github issue with the URL utilized',
+        ),
+      );
+    });
+  });
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,6 +2,7 @@ import path from 'path';
 import dontenv from 'dotenv';
 import '@testing-library/jest-dom/extend-expect';
 import fetchMock from 'jest-fetch-mock';
+import { TextEncoder, TextDecoder } from 'util';
 
 // Minimize console output when testing failure cases
 global.console.error = jest.fn();
@@ -9,3 +10,5 @@ global.console.error = jest.fn();
 dontenv.config({ path: path.resolve(__dirname, './.env.test') });
 
 global.fetch = fetchMock;
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;

--- a/lib/getNFTInfo.ts
+++ b/lib/getNFTInfo.ts
@@ -64,7 +64,7 @@ export async function getMimeType(mediaUrl: string) {
   }
 }
 
-function supportedMedia(
+export function supportedMedia(
   nft: NFTResponseData,
   forceImage?: boolean,
 ): { mediaUrl: string; mediaMimeType: string } {
@@ -132,11 +132,7 @@ export function convertIPFS(uri?: string): string | undefined {
       );
     }
   } catch (e) {
-    if ((e as any).message !== 'url is not string') {
-      // got an annoying false positive message here; uri would definitely be
-      // type string but the error would be raised anyway. Skipping those.
-      captureException(e);
-    }
+    captureException(e);
   }
   return uri;
 }

--- a/lib/getNFTInfo.ts
+++ b/lib/getNFTInfo.ts
@@ -1,6 +1,9 @@
 import { captureException } from '@sentry/nextjs';
 import { ethers } from 'ethers';
 import { NFTResponseData } from 'pages/api/nftInfo/[uri]';
+import IPFSGatewayTools from '@pinata/ipfs-gateway-tools/dist/node';
+
+const ipfsGatewayTools = new IPFSGatewayTools();
 
 export interface GetNFTInfoResponse {
   name: string;
@@ -26,10 +29,13 @@ export async function getNFTInfoFromTokenInfo(
       return null;
     }
 
-    const { mediaUrl, mediaMimeType } = await supportedMedia(
-      NFTInfo,
-      forceImage,
-    );
+    if (isDataUri) {
+      // TODO: make this type safe. Since this is a data URI, it hasn't been
+      // transformed the way the API does the non-data ones.
+      Object.assign(NFTInfo, await getMedia(NFTInfo as any));
+    }
+
+    const { mediaUrl, mediaMimeType } = supportedMedia(NFTInfo, forceImage);
 
     return {
       id: tokenId,
@@ -58,10 +64,10 @@ export async function getMimeType(mediaUrl: string) {
   }
 }
 
-async function supportedMedia(
+function supportedMedia(
   nft: NFTResponseData,
   forceImage?: boolean,
-): Promise<{ mediaUrl: string; mediaMimeType: string }> {
+): { mediaUrl: string; mediaMimeType: string } {
   const { animation, image } = nft!;
 
   if (!animation && !image) {
@@ -73,4 +79,64 @@ async function supportedMedia(
   }
 
   return animation!;
+}
+
+export type Media = { mediaUrl: string; mediaMimeType: string } | null;
+
+interface TokenInfo {
+  image?: string;
+  image_url?: string;
+  animation_url?: string;
+}
+
+/**
+ * Given the object returned from fetching a token URI, return the media links
+ * and mime types associated with it (if any).
+ */
+export async function getMedia({
+  animation_url,
+  image,
+  image_url,
+}: TokenInfo): Promise<{ image: Media; animation: Media }> {
+  const finalImage = convertIPFS(image || image_url);
+  const finalAnimation = convertIPFS(animation_url);
+
+  const [animationMimeType, imageMimeType] = await Promise.all([
+    getMimeType(animation_url || ''),
+    getMimeType(image || ''),
+  ]);
+
+  return {
+    image: finalImage
+      ? { mediaUrl: finalImage, mediaMimeType: imageMimeType }
+      : null,
+    animation: finalAnimation
+      ? { mediaUrl: finalAnimation, mediaMimeType: animationMimeType }
+      : null,
+  };
+}
+
+/**
+ * If `uri` is an IPFS uri, convert to use our gateway. Otherwise return it untouched.
+ */
+export function convertIPFS(uri?: string): string | undefined {
+  if (!uri) {
+    return uri;
+  }
+
+  try {
+    if (ipfsGatewayTools.containsCID(uri).containsCid) {
+      return ipfsGatewayTools.convertToDesiredGateway(
+        uri,
+        'https://nftpawnshop.mypinata.cloud',
+      );
+    }
+  } catch (e) {
+    if ((e as any).message !== 'url is not string') {
+      // got an annoying false positive message here; uri would definitely be
+      // type string but the error would be raised anyway. Skipping those.
+      captureException(e);
+    }
+  }
+  return uri;
 }

--- a/pages/api/nftInfo/[uri].ts
+++ b/pages/api/nftInfo/[uri].ts
@@ -1,11 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import IPFSGatewayTools from '@pinata/ipfs-gateway-tools/dist/node';
 import { captureException, withSentry } from '@sentry/nextjs';
-import { getMimeType } from 'lib/getNFTInfo';
-
-const ipfsGatewayTools = new IPFSGatewayTools();
-
-type Media = { mediaUrl: string; mediaMimeType: string } | null;
+import { convertIPFS, getMedia, Media } from 'lib/getNFTInfo';
 
 export type NFTResponseData = {
   name: string;
@@ -40,24 +35,13 @@ async function handler(
       external_url,
     } = await tokenURIRes.json();
 
-    const finalImage = convertIPFS(image || image_url);
-    const finalAnimation = convertIPFS(animation_url);
-
-    const [animationMimeType, imageMimeType] = await Promise.all([
-      getMimeType(animation_url || ''),
-      getMimeType(image || ''),
-    ]);
+    const media = await getMedia({ animation_url, image, image_url });
 
     res.status(200).json({
       name,
       description,
       tokenId,
-      image: finalImage
-        ? { mediaUrl: finalImage, mediaMimeType: imageMimeType }
-        : null,
-      animation: finalAnimation
-        ? { mediaUrl: finalAnimation, mediaMimeType: animationMimeType }
-        : null,
+      ...media,
       external_url,
     });
   } catch (e) {
@@ -74,31 +58,6 @@ async function handler(
     // TODO: we could respond with a failure reason and surface that in the UI.
     return res.status(404).json(null);
   }
-}
-
-/**
- * If `uri` is an IPFS uri, convert to use our gateway. Otherwise return it untouched.
- */
-function convertIPFS(uri?: string): string | undefined {
-  if (!uri) {
-    return uri;
-  }
-
-  try {
-    if (ipfsGatewayTools.containsCID(uri).containsCid) {
-      return ipfsGatewayTools.convertToDesiredGateway(
-        uri,
-        'https://nftpawnshop.mypinata.cloud',
-      );
-    }
-  } catch (e) {
-    if ((e as any).message !== 'url is not string') {
-      // got an annoying false positive message here; uri would definitely be
-      // type string but the error would be raised anyway. Skipping those.
-      captureException(e);
-    }
-  }
-  return uri;
 }
 
 export default withSentry(handler);


### PR DESCRIPTION
The NFTInfo API has been a source of some problems, breaking it into pieces to make it more testable. Also fixes bug where data URIs didn't provide the expected mime types