### PR TITLE
NFT-298 fix: fallback wrapped with media container

### DIFF
--- a/components/LoanCard/LoanCard.tsx
+++ b/components/LoanCard/LoanCard.tsx
@@ -134,7 +134,9 @@ export function LoanCardLoading({
     <Link href={`/loans/${id}`}>
       <a className={styles['profile-link']}>
         <div className={styles['profile-card']}>
-          <Fallback />
+          <div className={styles.media}>
+            <Fallback />
+          </div>
           <div className={styles['profile-card-attributes']}>
             <span>loading name</span>
             {children}


### PR DESCRIPTION
| before | after |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/9300702/165546002-ec3b40e8-1568-4070-a0d2-95ebeb8062f8.png) | ![image](https://user-images.githubusercontent.com/9300702/165546078-60325bb8-f66e-4a8f-b08b-18062298fbab.png) |

When we last updated the loancard styles we forgot to treat the loading fallback the same way, this PR updates and everything feels a bit nicer, since the homepage doesn't jump around nearly as much while loading images