### PR TITLE
trivial: use Media type in bot attachments

### DIFF
--- a/lib/events/consumers/getNftInfoForAttachment.ts
+++ b/lib/events/consumers/getNftInfoForAttachment.ts
@@ -1,3 +1,5 @@
+import { siteUrl } from 'lib/chainEnv';
+import { getMedia } from 'lib/getNFTInfo';
 import { NFTResponseData } from 'pages/api/nftInfo/[uri]';
 
 const JSON_PREFIX = 'data:application/json;base64,';
@@ -16,13 +18,15 @@ export async function getNFTInfoForAttachment(
         'base64',
       ).toString(),
     );
+
+    // TODO: make this type safe. Since this is a data URI, it hasn't been
+    // transformed the way the API does the non-data ones.
+    Object.assign(NFTInfo, await getMedia(NFTInfo as any));
   } else {
     const tokenURIRes = await fetch(
       isDataUri
         ? collateralTokenURI
-        : `https://rinkeby.withbacked.xyz/api/nftInfo/${encodeURIComponent(
-            collateralTokenURI,
-          )}`,
+        : `${siteUrl()}/api/nftInfo/${encodeURIComponent(collateralTokenURI)}`,
     );
     NFTInfo = await tokenURIRes.json();
   }


### PR DESCRIPTION
Just conforms NFTResponseInfo type similarly to other ways it is used throughout codebase. Instead of .image, we can now safely do .image.mediaUrl