### PR TITLE
NFT-331: liquidation emails to iterate through all chains

### DIFF
--- a/__tests__/api/events/cron/processTimelyEvents.test.ts
+++ b/__tests__/api/events/cron/processTimelyEvents.test.ts
@@ -53,6 +53,12 @@ describe('/api/events/cron/processTimelyEvents', () => {
 
     await handler(req, res);
 
+    expect(mockedGetLiquidatedLoansCall).toHaveBeenCalledTimes(1);
+    expect(mockedGetLiquidatedLoansCall).toHaveBeenCalledWith(
+      expect.anything(),
+      configs.rinkeby,
+    );
+
     expect(sendEmailsForTriggerAndEntity).toHaveBeenCalledTimes(2);
     expect(sendEmailsForTriggerAndEntity).toHaveBeenCalledWith(
       'LiquidationOccurring',

--- a/__tests__/lib/events/timely/timely.test.ts
+++ b/__tests__/lib/events/timely/timely.test.ts
@@ -7,6 +7,7 @@ import {
   getLastWrittenTimestamp,
   overrideLastWrittenTimestamp,
 } from 'lib/events/consumers/userNotifications/repository';
+import { configs } from 'lib/config';
 
 let lastRun = 1645155901;
 let now = lastRun + 3600;
@@ -62,14 +63,19 @@ describe('getLiquidatedLoansForTimestamp', () => {
     fetchMock.mockResponse('success');
 
     const { liquidationOccurringLoans, liquidationOccurredLoans } =
-      await getLiquidatedLoansForTimestamp(now);
+      await getLiquidatedLoansForTimestamp(now, configs.rinkeby);
 
     expect(mockedGetExpiringLoansCall).toHaveBeenCalledTimes(2);
     expect(mockedGetExpiringLoansCall).toHaveBeenCalledWith(
       now + 24 * 3600,
       now + 25 * 3600,
+      configs.rinkeby,
     );
-    expect(mockedGetExpiringLoansCall).toHaveBeenCalledWith(now - 3600, now);
+    expect(mockedGetExpiringLoansCall).toHaveBeenCalledWith(
+      now - 3600,
+      now,
+      configs.rinkeby,
+    );
 
     expect(liquidationOccurringLoans).toEqual([aboutToExpireLoan]);
     expect(liquidationOccurredLoans).toEqual([alreadyExpiredLoan]);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -60,6 +60,10 @@ export const configs = {
   rinkeby,
 };
 
+export const prodConfigs = [ethereum];
+
+export const devConfigs = [rinkeby];
+
 const SUPPORTED_NETWORKS = new Set(Object.keys(configs));
 
 export function isSupportedNetwork(

--- a/lib/events/timely/timely.ts
+++ b/lib/events/timely/timely.ts
@@ -1,3 +1,4 @@
+import { Config } from 'lib/config';
 import { getLoansExpiringWithin } from 'lib/loans/subgraph/subgraphLoans';
 import { Loan } from 'types/generated/graphql/nftLoans';
 import {
@@ -14,6 +15,7 @@ type LiquidatedLoans = {
 
 export async function getLiquidatedLoansForTimestamp(
   currentTimestamp: number,
+  config: Config,
 ): Promise<LiquidatedLoans> {
   const notificationsFreq = parseInt(
     process.env.NEXT_PUBLIC_NOTIFICATIONS_FREQUENCY_HOURS!,
@@ -38,11 +40,13 @@ export async function getLiquidatedLoansForTimestamp(
   const liquidationOccurringLoans = await getLoansExpiringWithin(
     currentRunTimestamp + HOURS_IN_DAY * 3600,
     currentRunTimestamp + (HOURS_IN_DAY + notificationsFreq) * 3600,
+    config,
   );
 
   const liquidationOccurredLoans = await getLoansExpiringWithin(
     currentRunTimestamp - notificationsFreq * 3600,
     currentRunTimestamp,
+    config,
   );
 
   await overrideLastWrittenTimestamp(currentTimestamp);

--- a/lib/loans/subgraph/subgraphLoans.ts
+++ b/lib/loans/subgraph/subgraphLoans.ts
@@ -1,4 +1,4 @@
-import { nftBackedLoansClient } from '../../urql';
+import { nftBackedLoansClient, nftBackedLoansClientFromConfig } from 'lib/urql';
 import {
   QueryLoansArgs,
   Loan,
@@ -21,6 +21,7 @@ import { daysToSecondsBigNum } from 'lib/duration';
 import { CombinedError } from 'urql';
 import { INTEREST_RATE_PERCENT_DECIMALS } from 'lib/constants';
 import { captureException } from '@sentry/nextjs';
+import { Config } from 'lib/config';
 
 // TODO(Wilson): this is a temp fix just for this query. We should generalize this method to
 // take an arguments and return a cursor to return paginated results
@@ -142,7 +143,10 @@ const formatInterestForGraph = (interest: number): string => {
 export async function getLoansExpiringWithin(
   timeOne: number,
   timeTwo: number,
+  config: Config,
 ): Promise<Loan[]> {
+  const nftBackedLoansClient = nftBackedLoansClientFromConfig(config);
+
   const where: Loan_Filter = {
     endDateTimestamp_gt: timeOne,
     endDateTimestamp_lt: timeTwo,


### PR DESCRIPTION
Our timely notifications should run in two envs: 'prod' and 'dev'.

Prod represents all our mainnet chains: eth, optimism, polygon. Dev is our testnets, so currently just rinkeby.

This PR ensures we iterate through all the right chains when sending liquidation emails.
