### PR TITLE
fix: fixed price on mock sale data

### DIFF
--- a/lib/nftSalesSubgraph.ts
+++ b/lib/nftSalesSubgraph.ts
@@ -73,7 +73,7 @@ export const generateFakeSaleForNFT = (
     nftTokenId,
     saleType: SaleType.Single,
     paymentToken: Object.keys(PAYMENT_TOKENS)[randomNumber(1)],
-    price: ethers.utils.formatUnits(randomNumber(1000)), // BigInts get sent down the wire as strings with TheGraph
+    price: '12500000000000000000',
     exchange: Object.keys(NFT_EXCHANGES)[randomNumber(1)],
     timestamp: new Date(2020, randomNumber(11), 15).getTime(),
   };


### PR DESCRIPTION
When on Rinkeby we generate mock sales data for NFTs just so we have something to render on the page. The original generation code would produce values that couldn't be parsed as BigNumbers so we'd get 500 errors on loan pages. This PR makes it return a constant amount that does not produce issues.