### PR TITLE
fix: object-position:bottom only on LoanCard

### DIFF
--- a/components/LoanCard/LoanCard.module.css
+++ b/components/LoanCard/LoanCard.module.css
@@ -76,6 +76,10 @@
   max-height: 350px;
 }
 
+.media > img {
+  object-position: bottom;
+}
+
 .loading-media {
   overflow: hidden;
   height: 0;

--- a/components/Media/Media.module.css
+++ b/components/Media/Media.module.css
@@ -56,5 +56,5 @@
   height: 100%;
   justify-self: center;
   object-fit: contain;
-  object-position: bottom;
+  object-position: top;
 }


### PR DESCRIPTION
Last time we adjusted the `<Media>` component for use on `<LoanCard>` we accidentally made it so that the image would chase the form down the page. This PR updates it so that we only position the image to the bottom in the `<LoanCard>`

| before | after |
| ----- | ----- |
| ![image](https://user-images.githubusercontent.com/9300702/168335290-98931511-9728-46b0-8b61-8d1f3d11ca30.png) | ![image](https://user-images.githubusercontent.com/9300702/168335392-daee1462-f576-44c6-8055-ef13daaf2a47.png) |
