### PR TITLE
fix: don't fetch undefined media URLs

### DIFF
--- a/lib/getNFTInfo.ts
+++ b/lib/getNFTInfo.ts
@@ -58,8 +58,13 @@ export async function getNFTInfoFromTokenInfo({
   }
 }
 
-export async function getMimeType(mediaUrl: string) {
+export async function getMimeType(mediaUrl?: string) {
   const defaultMimeType = 'application/octet-stream';
+
+  if (!mediaUrl) {
+    return defaultMimeType;
+  }
+
   try {
     const res = await fetch(mediaUrl, { method: 'HEAD' });
     // If we get no mime type in headers, we don't know what the MIME type is
@@ -110,8 +115,8 @@ export async function getMedia({
   const finalAnimation = convertIPFS(animation_url);
 
   const [animationMimeType, imageMimeType] = await Promise.all([
-    getMimeType(animation_url || ''),
-    getMimeType(image || ''),
+    getMimeType(finalAnimation),
+    getMimeType(finalImage),
   ]);
 
   return {


### PR DESCRIPTION
fixes: https://sentry.io/organizations/non-fungible-finance/issues/3271283999/?project=6318688&query=is%3Aunresolved
Basically, we would just yeet all possible media url fields into fetch to try and get the mime type. This caused a lot of errors to be logged when we would try to fetch nonexistent URLs -- now we return early when we don't have a URL to look at.