### PR TITLE
NFT-337: Pass contract address to png buffer to fix UniV3

### DIFF
--- a/lib/events/consumers/attachmentsHelper.ts
+++ b/lib/events/consumers/attachmentsHelper.ts
@@ -1,8 +1,12 @@
 import axios from 'axios';
 
-export async function getPngBufferFromBase64SVG(base: string): Promise<string> {
+export async function getPngBufferFromBase64SVG(
+  base: string,
+  contractAddress: string,
+): Promise<string> {
   const pngBufferRes = await axios.post(`${process.env.SVG_TO_PNG_URL!}`, {
     svg: base,
+    contractAddress,
   });
   return pngBufferRes.data.pngBuffer;
 }

--- a/lib/events/consumers/discord/attachments.ts
+++ b/lib/events/consumers/discord/attachments.ts
@@ -9,6 +9,7 @@ export async function collateralToDiscordMessageEmbed(
   nftResponseData: NFTResponseData,
   collateralName: string,
   collateralTokenId: ethers.BigNumber,
+  contractAddress: string,
 ): Promise<MessageEmbed | undefined> {
   let rawBufferAttachment: MessageAttachment | undefined = undefined;
   let messageEmbed: MessageEmbed;
@@ -16,6 +17,7 @@ export async function collateralToDiscordMessageEmbed(
   if (nftResponseData?.image?.mediaUrl.startsWith(SVG_PREFIX)) {
     const pngBuffer = await getPngBufferFromBase64SVG(
       nftResponseData!.image!.mediaUrl,
+      contractAddress,
     );
 
     rawBufferAttachment = new MessageAttachment(

--- a/lib/events/consumers/discord/formatter.ts
+++ b/lib/events/consumers/discord/formatter.ts
@@ -54,6 +54,7 @@ Event Tx: <${config.etherscanUrl}/tx/${event.id}>
     ),
     event.loan.collateralName,
     event.loan.collateralTokenId,
+    event.loan.collateralContractAddress,
   );
 
   await sendBotMessage(botMessageContent, messagedEmbed);

--- a/lib/events/consumers/twitter/attachments.ts
+++ b/lib/events/consumers/twitter/attachments.ts
@@ -6,9 +6,13 @@ const SVG_PREFIX = 'data:image/svg+xml;base64,';
 
 export async function nftResponseDataToImageBuffer(
   nftResponseData: NFTResponseData,
+  contractAddress: string,
 ): Promise<string | undefined> {
   if (nftResponseData?.image?.mediaUrl.startsWith(SVG_PREFIX)) {
-    return await getPngBufferFromBase64SVG(nftResponseData!.image!.mediaUrl);
+    return await getPngBufferFromBase64SVG(
+      nftResponseData!.image!.mediaUrl,
+      contractAddress,
+    );
   } else {
     const imageUrlRes = await fetch(nftResponseData!.image!.mediaUrl);
     const arraybuffer = await imageUrlRes.arrayBuffer();

--- a/lib/events/consumers/twitter/formatter.ts
+++ b/lib/events/consumers/twitter/formatter.ts
@@ -51,6 +51,7 @@ ${loanUrl(event.loan.id, config)}
       config.siteUrl,
       config.network as SupportedNetwork,
     ),
+    event.loan.collateralContractAddress,
   );
 
   await tweet(tweetContent, attachmentImageBuffer);


### PR DESCRIPTION
Will go along with: https://github.com/with-backed/svg-to-png-buffer/pull/2

This PR passes the NFT contract address to our PNG buffer generator API so that it knows to generate univ3 buffers in a different way