### PR TITLE
NFT-339 feat: dynamic css for optimism & polygon

### DIFF
--- a/__tests__/hooks/useNetworkSpecificStyles.test.ts
+++ b/__tests__/hooks/useNetworkSpecificStyles.test.ts
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useNetworkSpecificStyles } from 'hooks/useNetworkSpecificStyles';
+import { STYLE_MAP } from 'hooks/useNetworkSpecificStyles/useNetworkSpecificStyles';
+import { configs, SupportedNetwork } from 'lib/config';
+
+const setPropertySpy = jest.spyOn(
+  global.document.documentElement.style,
+  'setProperty',
+);
+
+describe('useNetworkSpecificStyles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it.each(Object.keys(configs).map((name) => [name]))(
+    'calls setProperty the right number of times for %s',
+    (network) => {
+      expect(setPropertySpy).not.toHaveBeenCalled();
+      renderHook(() => useNetworkSpecificStyles(network as SupportedNetwork));
+      expect(setPropertySpy).toHaveBeenCalledTimes(
+        STYLE_MAP[network as SupportedNetwork].length,
+      );
+    },
+  );
+});

--- a/components/Banner/Banner.module.css
+++ b/components/Banner/Banner.module.css
@@ -29,6 +29,16 @@
   background-color: var(--highlight-active-5);
 }
 
+.optimism {
+  composes: banner;
+  background-color: var(--optimistic-red-10);
+}
+
+.polygon {
+  composes: banner;
+  background-color: var(--polygon-purple-10);
+}
+
 .inner {
   text-align: center;
 }
@@ -57,4 +67,18 @@
 
 .info > .close {
   background-color: var(--neutral-100);
+}
+
+.optimism > .close {
+  background-color: var(--optimistic-red-100);
+}
+.optimism button {
+  color: var(--optimistic-red-100);
+}
+
+.polygon > .close {
+  background-color: var(--polygon-purple-100);
+}
+.polygon button {
+  color: var(--polygon-purple-100);
 }

--- a/components/Banner/Banner.tsx
+++ b/components/Banner/Banner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './Banner.module.css';
 
-export type BannerKind = 'error' | 'success' | 'info';
+export type BannerKind = 'error' | 'success' | 'info' | 'optimism' | 'polygon';
 
 type BannerProps = {
   kind: BannerKind;

--- a/components/Banner/messages/WrongNetwork.tsx
+++ b/components/Banner/messages/WrongNetwork.tsx
@@ -1,13 +1,21 @@
 import { TextButton } from 'components/Button';
 import { ethers } from 'ethers';
 import { useGlobalMessages } from 'hooks/useGlobalMessages';
+import { SupportedNetwork } from 'lib/config';
 import React, { useCallback, useMemo } from 'react';
 import { useNetwork } from 'wagmi';
-import { Banner } from '../Banner';
+import { Banner, BannerKind } from '../Banner';
+
+const BANNER_CLASS_MAP: { [network in SupportedNetwork]: BannerKind } = {
+  ethereum: 'error',
+  rinkeby: 'error',
+  optimism: 'optimism',
+  polygon: 'polygon',
+};
 
 type WrongNetworkProps = {
   expectedChainId: number;
-  expectedChainName: string;
+  expectedChainName: SupportedNetwork;
 };
 export const WrongNetwork = ({
   expectedChainId,
@@ -48,7 +56,7 @@ export const WrongNetwork = ({
 
   if (chainId && chainId !== expectedChainId) {
     return (
-      <Banner kind="error">
+      <Banner kind={BANNER_CLASS_MAP[expectedChainName]}>
         <span>
           You&apos;re viewing data from the {formattedExpectedName} network, but
           your wallet is connected to the {currentChainName} network.{' '}

--- a/components/PawnShopHeader/PawnShopHeader.tsx
+++ b/components/PawnShopHeader/PawnShopHeader.tsx
@@ -16,6 +16,7 @@ import { useOnClickOutside } from 'hooks/useOnClickOutside';
 import { useConfig } from 'hooks/useConfig';
 import { Logo } from 'components/Logo';
 import { NetworkSelector } from 'components/NetworkSelector';
+import { SupportedNetwork } from 'lib/config';
 
 type PawnShopHeaderProps = {
   isErrorPage?: boolean;
@@ -54,7 +55,10 @@ export const PawnShopHeader: FunctionComponent<PawnShopHeaderProps> = ({
     <>
       <div className={styles['banner-container']}>
         {!isErrorPage && (
-          <WrongNetwork expectedChainId={chainId} expectedChainName={network} />
+          <WrongNetwork
+            expectedChainId={chainId}
+            expectedChainName={network as SupportedNetwork}
+          />
         )}
         {messages.map((m) => {
           const close = () => removeMessage(m);

--- a/hooks/useNetworkSpecificStyles/index.ts
+++ b/hooks/useNetworkSpecificStyles/index.ts
@@ -1,0 +1,1 @@
+export { useNetworkSpecificStyles } from './useNetworkSpecificStyles';

--- a/hooks/useNetworkSpecificStyles/useNetworkSpecificStyles.ts
+++ b/hooks/useNetworkSpecificStyles/useNetworkSpecificStyles.ts
@@ -10,12 +10,8 @@ const BASE_RADIAL: StyleRule = [RADIAL_NAME, RADIAL_DEFAULT];
 export const STYLE_MAP: { [network in SupportedNetwork]: StyleRule[] } = {
   ethereum: [BASE_RADIAL],
   rinkeby: [BASE_RADIAL],
-  optimism: [
-    [RADIAL_NAME, 'radial-gradient(#ffffff, var(--optimistic-red-10))'],
-  ],
-  polygon: [
-    [RADIAL_NAME, 'radial-gradient(#ffffff, var(--polygon-purple-10))'],
-  ],
+  optimism: [[RADIAL_NAME, 'var(--optimistic-red-10)']],
+  polygon: [[RADIAL_NAME, 'var(--polygon-purple-10)']],
 };
 
 export function useNetworkSpecificStyles(network: SupportedNetwork) {

--- a/hooks/useNetworkSpecificStyles/useNetworkSpecificStyles.ts
+++ b/hooks/useNetworkSpecificStyles/useNetworkSpecificStyles.ts
@@ -1,0 +1,28 @@
+import { SupportedNetwork } from 'lib/config';
+import { useEffect } from 'react';
+
+type StyleRule = [variableName: string, style: string];
+
+const RADIAL_NAME = '--background-radial-gradient';
+const RADIAL_DEFAULT = 'radial-gradient(#ffffff, #f6f2f0)';
+const BASE_RADIAL: StyleRule = [RADIAL_NAME, RADIAL_DEFAULT];
+
+export const STYLE_MAP: { [network in SupportedNetwork]: StyleRule[] } = {
+  ethereum: [BASE_RADIAL],
+  rinkeby: [BASE_RADIAL],
+  optimism: [
+    [RADIAL_NAME, 'radial-gradient(#ffffff, var(--optimistic-red-10))'],
+  ],
+  polygon: [
+    [RADIAL_NAME, 'radial-gradient(#ffffff, var(--polygon-purple-10))'],
+  ],
+};
+
+export function useNetworkSpecificStyles(network: SupportedNetwork) {
+  useEffect(() => {
+    const rules = STYLE_MAP[network];
+    rules.forEach(([variableName, style]) => {
+      document.documentElement.style.setProperty(variableName, style);
+    });
+  }, [network]);
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { SupportedNetwork, isSupportedNetwork } from 'lib/config';
 import { ApplicationProviders } from 'components/ApplicationProviders';
+import { useNetworkSpecificStyles } from 'hooks/useNetworkSpecificStyles';
 
 export default function App({ Component, pageProps }: AppProps) {
   const { query } = useRouter();
@@ -18,6 +19,7 @@ export default function App({ Component, pageProps }: AppProps) {
       ? (query.network as SupportedNetwork)
       : 'ethereum',
   );
+  useNetworkSpecificStyles(network);
 
   useEffect(() => {
     if (query.network) {

--- a/styles/global.css
+++ b/styles/global.css
@@ -24,6 +24,10 @@
   --neutral-20: #e6ded6;
   --neutral-10: #f4f0ec;
   --neutral-5: #f9f7f5;
+  --optimistic-red-10: #fff5f4;
+  --optimistic-red-100: #fe0420;
+  --polygon-purple-10: #f8f5ff;
+  --polygon-purple-100: #7b3fe4;
 
   /* layout */
   --max-width-header: 1224px;


### PR DESCRIPTION
Let's make these backgrounds optimism-branded to help make sure people realize the difference. 

The "switch to Optimism" banner uses new colors:

`optimistic-red-10: #FFF5F4`

`optimistic-red-100: #FE0420`

and the --background-radial-gradient updates it's second value from `#f6f2f0` to `optimistic-red-10` . We can use this background on the Profile page too, but Loan pages keep their unique background.

While we're rigging this up, we might as well add polygon-purple for later:

`polygon-purple-10: #F8F5FF`

`polygon-purple-100: #7B3FE4`

![optimism](https://user-images.githubusercontent.com/9300702/169306319-cbdc7aae-b153-4a92-a6c5-d423b626f4b6.png)

