### PR TITLE
NFT-323 feat: start to use string constants on LoanForm

### DIFF
--- a/components/LoanForm/LoanForm.tsx
+++ b/components/LoanForm/LoanForm.tsx
@@ -19,6 +19,7 @@ import { useAccount } from 'wagmi';
 import { LoanOfferBetterTermsDisclosure } from 'components/LoanForm/LoanOfferBetterTermsDisclosure';
 import { useConfig } from 'hooks/useConfig';
 import { SupportedNetwork } from 'lib/config';
+import { BETTER_TERMS_LABEL, LEND_LABEL } from './strings';
 
 type LoanFormProps = {
   loan: Loan;
@@ -71,7 +72,9 @@ export function LoanForm({ loan, refresh }: LoanFormProps) {
   if (!account) {
     return (
       <div className={styles.wrapper}>
-        <Button disabled>{loan.lender ? 'Offer better terms' : 'Lend'}</Button>
+        <Button disabled>
+          {loan.lender ? BETTER_TERMS_LABEL : LEND_LABEL}
+        </Button>
       </div>
     );
   }
@@ -103,7 +106,7 @@ export function LoanForm({ loan, refresh }: LoanFormProps) {
 
   if (loan.lastAccumulatedTimestamp.eq(0)) {
     return (
-      <LoanFormDisclosure title={'Lend'} className={styles.wrapper}>
+      <LoanFormDisclosure title={LEND_LABEL} className={styles.wrapper}>
         <div className={styles['form-wrapper']}>
           <LoanFormAwaiting
             balance={balance}
@@ -154,7 +157,7 @@ export function LoanForm({ loan, refresh }: LoanFormProps) {
   }
 
   return (
-    <LoanFormDisclosure title={'Offer better terms'} className={styles.wrapper}>
+    <LoanFormDisclosure title={BETTER_TERMS_LABEL} className={styles.wrapper}>
       <div className={styles['form-wrapper']}>
         <LoanFormBetterTerms
           balance={balance}

--- a/components/LoanForm/LoanFormBetterTerms/LoanFormBetterTerms.tsx
+++ b/components/LoanForm/LoanFormBetterTerms/LoanFormBetterTerms.tsx
@@ -22,6 +22,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { formattedAnnualRate } from 'lib/interest';
 import { LoanTermsDisclosure } from 'components/LoanTermsDisclosure';
 import { useLoanDetails } from 'hooks/useLoanDetails';
+import { BETTER_TERMS_LABEL } from '../strings';
 
 type LoanFormBetterTermsProps = {
   balance: number;
@@ -51,8 +52,7 @@ export function LoanFormBetterTerms({
     [loan.durationSeconds],
   );
   const [hasReviewed, setHasReviewed] = useState(false);
-  const { formattedInterestAccrued, formattedTotalPayback } =
-    useLoanDetails(loan);
+  const { formattedInterestAccrued } = useLoanDetails(loan);
 
   const form = useForm<LoanFormData>({
     defaultValues: {
@@ -219,7 +219,7 @@ export function LoanFormBetterTerms({
         />
         <TransactionButton
           id="Lend"
-          text="Offer better terms"
+          text={BETTER_TERMS_LABEL}
           type="submit"
           txHash={txHash}
           isPending={transactionPending}

--- a/components/LoanForm/strings.ts
+++ b/components/LoanForm/strings.ts
@@ -1,0 +1,2 @@
+export const BETTER_TERMS_LABEL = 'Lend at better terms';
+export const LEND_LABEL = 'Lend';


### PR DESCRIPTION
This PR updates the buyout text to make it more clear what happens during a buyout. Additionally, put some repeated strings into constants for easier updating. AFAICT these are the main repeated strings, though perhaps we'd eventually put form labels, etc. in there.