### PR TITLE
NFT-349 chore: onError param for useSigner

### DIFF
--- a/components/Button/AllowButton.tsx
+++ b/components/Button/AllowButton.tsx
@@ -5,6 +5,7 @@ import { authorizeCurrency } from 'lib/authorizations/authorizeCurrency';
 import { useSigner } from 'wagmi';
 import { useConfig } from 'hooks/useConfig';
 import { SupportedNetwork } from 'lib/config';
+import { captureException } from '@sentry/nextjs';
 
 interface AllowButtonProps {
   contractAddress: string;
@@ -20,7 +21,7 @@ export function AllowButton({
   done,
 }: AllowButtonProps) {
   const { network } = useConfig();
-  const { data: signer } = useSigner();
+  const { data: signer } = useSigner({ onError: captureException });
   const [txHash, setTxHash] = useState('');
   const [waitingForTx, setWaitingForTx] = useState(false);
 

--- a/components/CreatePageHeader/AuthorizeNFTButton.tsx
+++ b/components/CreatePageHeader/AuthorizeNFTButton.tsx
@@ -35,7 +35,7 @@ export function AuthorizeNFTButton({
 }: AuthorizeNFTButtonProps) {
   const { network } = useConfig();
   const { addMessage } = useGlobalMessages();
-  const { data: signer } = useSigner();
+  const { data: signer } = useSigner({ onError: captureException });
   const [transactionHash, setTransactionHash] = useState('');
   const [isPending, setIsPending] = useState(false);
   const [isCollateralApproved, setIsCollateralApproved] = useState(false);

--- a/components/CreatePageHeader/CreatePageForm.tsx
+++ b/components/CreatePageHeader/CreatePageForm.tsx
@@ -71,7 +71,7 @@ export function CreatePageForm({
   const { jsonRpcProvider, network } = useConfig();
   const { addMessage } = useGlobalMessages();
   const { data } = useAccount();
-  const { data: signer } = useSigner();
+  const { data: signer } = useSigner({ onError: captureException });
   const account = data?.address;
   const buttonText = useMemo(() => 'Mint Borrower Ticket', []);
   const [txHash, setTxHash] = useState('');

--- a/components/LoanForm/LoanFormEarlyClosure/LoanFormEarlyClosure.tsx
+++ b/components/LoanForm/LoanFormEarlyClosure/LoanFormEarlyClosure.tsx
@@ -19,7 +19,7 @@ export function LoanFormEarlyClosure({
 }: LoanFormEarlyClosureProps) {
   const { network } = useConfig();
   const { addMessage } = useGlobalMessages();
-  const { data: signer } = useSigner();
+  const { data: signer } = useSigner({ onError: captureException });
   const [txHash, setTxHash] = useState('');
   const [isPending, setIsPending] = useState(false);
 

--- a/components/LoanForm/LoanFormRepay/LoanFormRepay.tsx
+++ b/components/LoanForm/LoanFormRepay/LoanFormRepay.tsx
@@ -32,7 +32,7 @@ export function LoanFormRepay({
   } = useLoanDetails(loan);
   const { network } = useConfig();
   const { addMessage } = useGlobalMessages();
-  const { data: signer } = useSigner();
+  const { data: signer } = useSigner({ onError: captureException });
   const [txHash, setTxHash] = useState('');
   const [waitingForTx, setWaitingForTx] = useState(false);
 

--- a/components/LoanForm/LoanFormSeizeCollateral/LoanFormSeizeCollateral.tsx
+++ b/components/LoanForm/LoanFormSeizeCollateral/LoanFormSeizeCollateral.tsx
@@ -23,7 +23,7 @@ export function LoanFormSeizeCollateral({
   const [txHash, setTxHash] = useState('');
   const [isPending, setIsPending] = useState(false);
 
-  const { data: signer } = useSigner();
+  const { data: signer } = useSigner({ onError: captureException });
 
   const seize = useCallback(async () => {
     const loanFacilitator = web3LoanFacilitator(

--- a/hooks/useLoanUnderwriter/useLoanUnderwriter.tsx
+++ b/hooks/useLoanUnderwriter/useLoanUnderwriter.tsx
@@ -24,7 +24,7 @@ export function useLoanUnderwriter(
   const [txHash, setTxHash] = useState('');
   const [transactionPending, setTransactionPending] = useState(false);
   const { data } = useAccount();
-  const { data: signer } = useSigner();
+  const { data: signer } = useSigner({ onError: captureException });
   const account = data?.address;
 
   const underwrite = useCallback(


### PR DESCRIPTION
Got some reports that `signer` wasn't available when people tried to perform transactions. Haven't been able to repro yet and formulating a plan to better handle that case. In the meantime, `useSigner` accepts an `onError` param that I'm adding here to get more visibility into this issue.