### PR TITLE
chore: loading="lazy" on NFT media

### DIFF
--- a/components/Media/Media.tsx
+++ b/components/Media/Media.tsx
@@ -39,7 +39,15 @@ export const Media: FunctionComponent<MediaProps> = ({
     return <Audio media={media} onError={onError} />;
   }
 
-  return <img className={styles.image} src={media} onError={onError} alt="" />;
+  return (
+    <img
+      className={styles.image}
+      src={media}
+      onError={onError}
+      loading="lazy"
+      alt=""
+    />
+  );
 };
 
 function Video({


### PR DESCRIPTION
This will defer loading of images that aren't near the viewport. see: https://caniuse.com/loading-lazy-attr

Could be a minor perf gain