### PR TITLE
fix: try-catches in nftInfo api

### DIFF
--- a/pages/api/network/[network]/nftInfo/[contractAddress]/[tokenId].ts
+++ b/pages/api/network/[network]/nftInfo/[contractAddress]/[tokenId].ts
@@ -27,17 +27,7 @@ async function handler(
 
     return res.status(200).json(metadata);
   } catch (e) {
-    if (e instanceof Error) {
-      if (
-        e.name === 'FetchError' &&
-        e.message.startsWith('invalid json response body')
-      ) {
-        // this happens when the root CID exists but the child file does not. No way to get the file, do nothing.
-      } else {
-        captureException(e);
-      }
-    }
-
+    captureException(e);
     // TODO: we could respond with a failure reason and surface that in the UI.
     return res.status(404).json(null);
   }
@@ -55,35 +45,61 @@ export async function getMetadata(
   contractAddress: string,
   tokenId: ethers.BigNumber,
 ): Promise<NFTResponseData> {
-  const { jsonRpcProvider } = configs[network];
-  const contract = jsonRpcERC721Contract(contractAddress, jsonRpcProvider);
-  const uri = await contract.tokenURI(ethers.BigNumber.from(tokenId));
-  const resolvedUri = convertIPFS(uri);
-  if (!resolvedUri) {
-    throw new Error(`Could not resolve ${uri}`);
+  try {
+    const { jsonRpcProvider } = configs[network];
+    const contract = jsonRpcERC721Contract(contractAddress, jsonRpcProvider);
+    const uri = await contract.tokenURI(ethers.BigNumber.from(tokenId));
+    const resolvedUri = convertIPFS(uri);
+    if (!resolvedUri) {
+      throw new Error(`Could not resolve ${uri}`);
+    }
+
+    const json = await getJson(resolvedUri);
+
+    if (!json) {
+      throw new Error(`Could not fetch json from ${uri}`);
+    }
+
+    const { name, description, image, image_url, animation_url, external_url } =
+      json;
+
+    const media = await getMedia({ animation_url, image, image_url });
+
+    return {
+      name,
+      description,
+      tokenId: tokenId.toNumber(),
+      ...media,
+      external_url,
+    };
+  } catch (e) {
+    captureException(e);
+    return null;
   }
-
-  const { name, description, image, image_url, animation_url, external_url } =
-    await getJson(resolvedUri);
-
-  const media = await getMedia({ animation_url, image, image_url });
-
-  return {
-    name,
-    description,
-    tokenId: tokenId.toNumber(),
-    ...media,
-    external_url,
-  };
 }
 
 async function getJson(uri: string) {
-  if (uri.startsWith(DATA_URI_PREFIX)) {
-    // TODO: not always base64? not always json?
-    const buffer = Buffer.from(uri.split(',')[1], 'base64');
-    return JSON.parse(buffer.toString());
-  } else {
-    const res = await fetch(uri);
-    return await res.json();
+  try {
+    if (uri.startsWith(DATA_URI_PREFIX)) {
+      // TODO: not always base64? not always json?
+      const buffer = Buffer.from(uri.split(',')[1], 'base64');
+      return JSON.parse(buffer.toString());
+    } else {
+      const res = await fetch(uri);
+      return await res.json();
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      if (
+        e.name === 'FetchError' &&
+        e.message.startsWith('invalid json response body')
+      ) {
+        // this happens when the root CID exists but the child file does not. No way to get the file, do nothing.
+      } else {
+        captureException(e);
+      }
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
I guess try-catch doesn't work like normal in NextJS api routes? :man_shrugging: 

The issue Wilson reported with 500s on Rinkeby should have been caught at the top level, but instead I had to handle in each function. I even wrote up a demo program to make sure I didn't forget how this is supposed to work:

```javascript
async function main() {
  try {
    await throwParent();
  } catch (e) {
    console.log(`got an error: ${e.message}`);
  }
}

async function thrower() {
  throw new Error('whoops!');
}

async function throwParent() {
  await thrower();
}

main();
```

and the top-level catch does perform as expected. welp.