### PR TITLE
NFT-370 fix: don't conflate time remaining and status

### DIFF
--- a/__tests__/components/LoanCard.test.tsx
+++ b/__tests__/components/LoanCard.test.tsx
@@ -45,12 +45,12 @@ describe('LoanCard', () => {
         isLoading: false,
         metadata: null,
       });
-      const { getAllByText } = render(
+      const { getByText } = render(
         <LoanCard loan={loan} selectedAddress="0xwhatever" />,
       );
-      const placeholders = getAllByText('--');
-      // one for the name we couldn't fetch, one for the time remaining
-      expect(placeholders).toHaveLength(2);
+
+      // the name we couldn't fetch
+      getByText('--');
     });
 
     it('renders a LoanCard', () => {

--- a/__tests__/hooks/useLoanDetails.test.ts
+++ b/__tests__/hooks/useLoanDetails.test.ts
@@ -27,7 +27,7 @@ describe('useLoanDetails', () => {
     expect(result.result.current.formattedLoanID).toEqual('Loan #8');
     expect(result.result.current.formattedPrincipal).toEqual('10 DAI');
     expect(result.result.current.formattedStatus).toEqual('No lender');
-    expect(result.result.current.formattedTimeRemaining).toEqual('no lender');
+    expect(result.result.current.formattedTimeRemaining).toEqual('--');
     expect(result.result.current.formattedTotalDuration).toEqual('3 days');
     expect(result.result.current.formattedTotalPayback).toEqual('10 DAI');
   });
@@ -47,9 +47,15 @@ describe('useLoanDetails', () => {
   });
   it('renders details with indication for past due loan', () => {
     const result = renderHook(() =>
-      useLoanDetails({ ...baseLoan, endDateTimestamp: 41 }),
+      useLoanDetails({
+        ...baseLoan,
+        endDateTimestamp: 41,
+        durationSeconds: ethers.BigNumber.from(1),
+        lastAccumulatedTimestamp: ethers.BigNumber.from(1),
+      }),
     );
-    expect(result.result.current.formattedTimeRemaining).toEqual('past due');
+    expect(result.result.current.formattedStatus).toEqual('Past due');
+    expect(result.result.current.formattedTimeRemaining).toEqual('0 days');
   });
   it('renders details with time remaining for accruing loan', () => {
     const result = renderHook(() =>

--- a/components/LoanCard/LoanCard.tsx
+++ b/components/LoanCard/LoanCard.tsx
@@ -179,7 +179,11 @@ export const ExpandedAttributes = ({ loan }: AttributesProps) => {
       </div>
       <div className={styles['stacked-entry']}>
         <dt>{statusLabel(formattedStatus)}</dt>
-        <dd>{formattedTimeRemaining}</dd>
+        <dd>
+          {formattedStatus === 'Accruing interest'
+            ? formattedTimeRemaining
+            : formattedStatus}
+        </dd>
       </div>
     </DescriptionList>
   );
@@ -209,7 +213,11 @@ export const CompactAttributes = ({ loan }: AttributesProps) => {
       </div>
       <div className={styles['stacked-entry']}>
         <dt>{statusLabel(formattedStatus)}</dt>
-        <dd>{formattedTimeRemaining}</dd>
+        <dd>
+          {formattedStatus === 'Accruing interest'
+            ? formattedTimeRemaining
+            : formattedStatus}
+        </dd>
       </div>
     </DescriptionList>
   );

--- a/hooks/useLoanDetails/useLoanDetails.ts
+++ b/hooks/useLoanDetails/useLoanDetails.ts
@@ -181,10 +181,10 @@ export function useLoanDetails(loan: Loan) {
       return '--';
     }
     if (endDateTimestamp === 0) {
-      return 'no lender';
+      return '--';
     }
     if (timestamp > endDateTimestamp) {
-      return 'past due';
+      return '0 days';
     }
     return truncate(secondsToDays(endDateTimestamp - timestamp), 2) + ' days';
   }, [endDateTimestamp, timestamp]);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/171253661-2ffad5bd-0624-486a-81a3-ec9f6a77a3ec.png)

This loan now properly shows its status as "Closed" rather than "Past Due." This happened because the hook that returns the remaining time had some statusy-things mixed in there. This PR separates them.