### PR TITLE
fix: no signer after page navigation

### DIFF
--- a/__tests__/components/NetworkSelector.test.tsx
+++ b/__tests__/components/NetworkSelector.test.tsx
@@ -5,16 +5,30 @@ import * as nextRouter from 'next/router';
 import { NetworkSelector } from 'components/NetworkSelector';
 
 jest.spyOn(nextRouter, 'useRouter');
+const originalLocation = global.location;
 
 const mockedUseRouter = nextRouter.useRouter as jest.MockedFunction<
   typeof nextRouter.useRouter
 >;
-const push = jest.fn();
 mockedUseRouter.mockImplementation(
-  () => ({ push, route: '/network/rinkeby/loans/create' } as any),
+  () => ({ route: '/network/rinkeby/loans/create' } as any),
 );
 
+const mockAssign = jest.fn();
+
 describe('Select', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        assign: mockAssign,
+      },
+    });
+  });
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+    });
+  });
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -43,12 +57,12 @@ describe('Select', () => {
       const rinkeby = rinkebys[1];
       userEvent.click(rinkeby);
 
-      expect(push).not.toHaveBeenCalled();
+      expect(mockAssign).not.toHaveBeenCalled();
     });
 
     it('handles selection on a loan page', () => {
       mockedUseRouter.mockImplementation(
-        () => ({ push, route: '/network/rinkeby/loans/1337' } as any),
+        () => ({ mockAssign, route: '/network/rinkeby/loans/1337' } as any),
       );
       const { getByText } = render(<NetworkSelector />);
 
@@ -59,13 +73,13 @@ describe('Select', () => {
       const optimism = getByText('Optimism');
       userEvent.click(optimism);
 
-      expect(push).toHaveBeenCalledWith('/network/optimism');
-      expect(push).toHaveBeenCalledTimes(1);
+      expect(mockAssign).toHaveBeenCalledWith('/network/optimism');
+      expect(mockAssign).toHaveBeenCalledTimes(1);
     });
 
     it('handles selection on the home page', () => {
       mockedUseRouter.mockImplementation(
-        () => ({ push, route: '/network/rinkeby' } as any),
+        () => ({ mockAssign, route: '/network/rinkeby' } as any),
       );
       const { getByText } = render(<NetworkSelector />);
 
@@ -76,13 +90,13 @@ describe('Select', () => {
       const optimism = getByText('Optimism');
       userEvent.click(optimism);
 
-      expect(push).toHaveBeenCalledWith('/network/optimism');
-      expect(push).toHaveBeenCalledTimes(1);
+      expect(mockAssign).toHaveBeenCalledWith('/network/optimism');
+      expect(mockAssign).toHaveBeenCalledTimes(1);
     });
 
     it('handles selection on the create page', () => {
       mockedUseRouter.mockImplementation(
-        () => ({ push, route: '/network/rinkeby/loans/create' } as any),
+        () => ({ mockAssign, route: '/network/rinkeby/loans/create' } as any),
       );
       const { getByText } = render(<NetworkSelector />);
 
@@ -93,13 +107,14 @@ describe('Select', () => {
       const optimism = getByText('Optimism');
       userEvent.click(optimism);
 
-      expect(push).toHaveBeenCalledWith('/network/optimism/loans/create');
-      expect(push).toHaveBeenCalledTimes(1);
+      expect(mockAssign).toHaveBeenCalledWith('/network/optimism/loans/create');
+      expect(mockAssign).toHaveBeenCalledTimes(1);
     });
 
     it('handles selection on the profile page', () => {
       mockedUseRouter.mockImplementation(
-        () => ({ push, route: '/network/rinkeby/profile/0xwhatever' } as any),
+        () =>
+          ({ mockAssign, route: '/network/rinkeby/profile/0xwhatever' } as any),
       );
       const { getByText } = render(<NetworkSelector />);
 
@@ -110,8 +125,10 @@ describe('Select', () => {
       const optimism = getByText('Optimism');
       userEvent.click(optimism);
 
-      expect(push).toHaveBeenCalledWith('/network/optimism/profile/0xwhatever');
-      expect(push).toHaveBeenCalledTimes(1);
+      expect(mockAssign).toHaveBeenCalledWith(
+        '/network/optimism/profile/0xwhatever',
+      );
+      expect(mockAssign).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/components/ApplicationProviders/ApplicationProviders.tsx
+++ b/components/ApplicationProviders/ApplicationProviders.tsx
@@ -46,16 +46,24 @@ export const ApplicationProviders = ({
 }: PropsWithChildren<ApplicationProvidersProps>) => {
   const { infuraId, alchemyId } = useConfig();
 
-  const { provider, chains } = configureChains(CHAINS, [
-    alchemyProvider({ alchemyId }),
-    infuraProvider({ infuraId }),
-    publicProvider(),
-  ]);
+  const { provider, chains } = useMemo(
+    () =>
+      configureChains(CHAINS, [
+        alchemyProvider({ alchemyId }),
+        infuraProvider({ infuraId }),
+        publicProvider(),
+      ]),
+    [alchemyId, infuraId],
+  );
 
-  const { connectors } = getDefaultWallets({
-    appName: 'Backed',
-    chains,
-  });
+  const { connectors } = useMemo(
+    () =>
+      getDefaultWallets({
+        appName: 'Backed',
+        chains,
+      }),
+    [chains],
+  );
 
   const client = useMemo(() => {
     return createClient({

--- a/components/NetworkSelector/NetworkSelector.tsx
+++ b/components/NetworkSelector/NetworkSelector.tsx
@@ -61,13 +61,13 @@ export const NetworkSelector = ({ isErrorPage }: NetworkSelectorProps) => {
         const currentPath = pathWithoutNetwork(route);
         const returnHome = shouldReturnToHomepage(currentPath);
         if (returnHome) {
-          push('/network/' + option.value);
+          window.location.assign('/network/' + option.value);
         } else {
-          push('/network/' + option.value + currentPath);
+          window.location.assign('/network/' + option.value + currentPath);
         }
       }
     },
-    [network, push, route],
+    [network, route],
   );
 
   const defaultValue = useMemo(

--- a/components/PawnShopHeader/PawnShopHeader.tsx
+++ b/components/PawnShopHeader/PawnShopHeader.tsx
@@ -1,4 +1,10 @@
-import React, { FunctionComponent, useCallback, useRef, useState } from 'react';
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import Link from 'next/link';
 import { ConnectWallet } from 'components/ConnectWallet';
 import styles from './PawnShopHeader.module.css';
@@ -17,6 +23,7 @@ import { useConfig } from 'hooks/useConfig';
 import { Logo } from 'components/Logo';
 import { NetworkSelector } from 'components/NetworkSelector';
 import { SupportedNetwork } from 'lib/config';
+import { useAccount, useSigner } from 'wagmi';
 
 type PawnShopHeaderProps = {
   isErrorPage?: boolean;
@@ -31,6 +38,8 @@ export const PawnShopHeader: FunctionComponent<PawnShopHeaderProps> = ({
 }) => {
   const { chainId, network } = useConfig();
   const { messages, removeMessage } = useGlobalMessages();
+  const { data: account } = useAccount({ onError: console.error });
+  const { data: signer } = useSigner({ onError: console.error });
   const { pathname } = useRouter();
   const kind = pathname.endsWith(CREATE_PATH) ? 'secondary' : 'primary';
   const codeActive = useKonami();
@@ -50,6 +59,8 @@ export const PawnShopHeader: FunctionComponent<PawnShopHeaderProps> = ({
     }
     setIsInfoCollapsed((prev) => !prev);
   }, [isInfoCollapsed, onCollapse]);
+
+  useEffect(() => console.log({ account, signer }), [account, signer]);
 
   return (
     <>

--- a/components/PawnShopHeader/PawnShopHeader.tsx
+++ b/components/PawnShopHeader/PawnShopHeader.tsx
@@ -1,10 +1,4 @@
-import React, {
-  FunctionComponent,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { FunctionComponent, useCallback, useRef, useState } from 'react';
 import Link from 'next/link';
 import { ConnectWallet } from 'components/ConnectWallet';
 import styles from './PawnShopHeader.module.css';
@@ -23,7 +17,6 @@ import { useConfig } from 'hooks/useConfig';
 import { Logo } from 'components/Logo';
 import { NetworkSelector } from 'components/NetworkSelector';
 import { SupportedNetwork } from 'lib/config';
-import { useAccount, useSigner } from 'wagmi';
 
 type PawnShopHeaderProps = {
   isErrorPage?: boolean;
@@ -38,8 +31,6 @@ export const PawnShopHeader: FunctionComponent<PawnShopHeaderProps> = ({
 }) => {
   const { chainId, network } = useConfig();
   const { messages, removeMessage } = useGlobalMessages();
-  const { data: account } = useAccount({ onError: console.error });
-  const { data: signer } = useSigner({ onError: console.error });
   const { pathname } = useRouter();
   const kind = pathname.endsWith(CREATE_PATH) ? 'secondary' : 'primary';
   const codeActive = useKonami();
@@ -59,8 +50,6 @@ export const PawnShopHeader: FunctionComponent<PawnShopHeaderProps> = ({
     }
     setIsInfoCollapsed((prev) => !prev);
   }, [isInfoCollapsed, onCollapse]);
-
-  useEffect(() => console.log({ account, signer }), [account, signer]);
 
   return (
     <>


### PR DESCRIPTION
wagmi doesn't like it when the client gets recreated. This occurred when navigating between pages, and also when changing networks. The fix is to stabilize the dependencies for the client creation so it doesn't re-spin, and also to make it so that changing network forces a full page load.

This should resolve our signer issues once and for all.