### PR TITLE
fix: set crossorigin on font preload

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -14,6 +14,7 @@ function FontLinks() {
           href={`${FONT_URL_PREFIX}/${f}.woff`}
           as="font"
           type="font/woff"
+          crossOrigin="anonymous"
         />
       ))}
     </>


### PR DESCRIPTION
The preload wouldn't work since we didn't set this attribute (didn't need it before since we were on same domain as fonts)