### PR TITLE
fix: add back error banners

### DIFF
--- a/__tests__/components/ErrorBanners.test.tsx
+++ b/__tests__/components/ErrorBanners.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ErrorBanners } from 'components/ErrorBanners';
+import { Message, useGlobalMessages } from 'hooks/useGlobalMessages';
+import { useRouter } from 'next/router';
+import { useNetwork } from 'wagmi';
+
+jest.mock('hooks/useGlobalMessages');
+jest.mock('next/router');
+jest.mock('wagmi');
+
+const mockedUseNetwork = useNetwork as jest.MockedFunction<typeof useNetwork>;
+const mockedUseGlobalMessages = useGlobalMessages as jest.MockedFunction<
+  typeof useGlobalMessages
+>;
+const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+mockedUseNetwork.mockReturnValue({
+  activeChain: { id: 1337 },
+  switchNetwork: jest.fn(),
+} as any);
+
+const messages: Message[] = [
+  { kind: 'error', message: 'it borked' },
+  { kind: 'info', message: 'it might bork' },
+  { kind: 'success', message: 'it worked' },
+];
+mockedUseGlobalMessages.mockReturnValue({
+  addMessage: jest.fn(),
+  removeMessage: jest.fn(),
+  messages,
+});
+
+mockedUseRouter.mockReturnValue({ pathname: '/loans/create' } as any);
+
+describe('ErrorBanners', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('renders WrongNetwork if you are on the wrong network', () => {
+    const { getByText } = render(<ErrorBanners />);
+    getByText(
+      "You're viewing data from the Rinkeby network, but your wallet is connected to the Unknown network.",
+    );
+  });
+
+  it('does not render WrongNetwork on error pages, because they have no network context', () => {
+    mockedUseRouter.mockReturnValueOnce({ pathname: '/404' } as any);
+    const { getByText } = render(<ErrorBanners />);
+    expect(() =>
+      getByText(
+        "You're viewing data from the Rinkeby network, but your wallet is connected to the Unknown network.",
+      ),
+    ).toThrowError();
+  });
+
+  it('renders all the messages currently in state', () => {
+    const { getByText } = render(<ErrorBanners />);
+    messages.forEach(({ message }) => {
+      getByText(message as string);
+    });
+  });
+});

--- a/components/ErrorBanners/ErrorBanners.module.css
+++ b/components/ErrorBanners/ErrorBanners.module.css
@@ -1,0 +1,6 @@
+.banners {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  width: 100%;
+}

--- a/components/ErrorBanners/ErrorBanners.tsx
+++ b/components/ErrorBanners/ErrorBanners.tsx
@@ -1,0 +1,38 @@
+import { Banner } from 'components/Banner';
+import { WrongNetwork } from 'components/Banner/messages';
+import { useConfig } from 'hooks/useConfig';
+import { useGlobalMessages } from 'hooks/useGlobalMessages';
+import { SupportedNetwork } from 'lib/config';
+import { useRouter } from 'next/router';
+import React, { useMemo } from 'react';
+import styles from './ErrorBanners.module.css';
+
+export function ErrorBanners() {
+  const { chainId, network } = useConfig();
+  const { messages, removeMessage } = useGlobalMessages();
+  const { pathname } = useRouter();
+  const isErrorPage = useMemo(
+    () => pathname === '/404' || pathname === '/500',
+    [pathname],
+  );
+
+  return (
+    <div className={styles.banners}>
+      {!isErrorPage && (
+        <WrongNetwork
+          expectedChainId={chainId}
+          expectedChainName={network as SupportedNetwork}
+        />
+      )}
+      {messages.map((m) => {
+        const close = () => removeMessage(m);
+        return (
+          // It's possible for a ReactNode to be null, but `message` shouldn't be on a banner.
+          <Banner key={m.message as any} kind={m.kind} close={close}>
+            {m.message}
+          </Banner>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/ErrorBanners/index.ts
+++ b/components/ErrorBanners/index.ts
@@ -1,0 +1,1 @@
+export { ErrorBanners } from './ErrorBanners';

--- a/components/Header/Header.module.css
+++ b/components/Header/Header.module.css
@@ -30,7 +30,8 @@
 
 .controls {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  max-width: 400px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 20px;
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,6 +12,7 @@ import { SupportedNetwork, isSupportedNetwork } from 'lib/config';
 import { ApplicationProviders } from 'components/ApplicationProviders';
 import { useNetworkSpecificStyles } from 'hooks/useNetworkSpecificStyles';
 import { Header } from 'components/Header';
+import { ErrorBanners } from 'components/ErrorBanners';
 
 export default function App({ Component, pageProps }: AppProps) {
   const { query } = useRouter();
@@ -36,6 +37,7 @@ export default function App({ Component, pageProps }: AppProps) {
     <ConfigProvider network={network}>
       <ApplicationProviders>
         <AppWrapper>
+          <ErrorBanners />
           <Header />
           <Component {...pageProps} />
           <Footer />


### PR DESCRIPTION
In #384 we accidentally removed the error banners, since they were part of the old header. This PR adds them back as their own separate component.

![image](https://user-images.githubusercontent.com/9300702/174166096-50c208ea-6cca-4d3a-941b-dedaa1bfcd4d.png)
