### PR TITLE
fix: pirsch sometimes not available

### DIFF
--- a/components/AdvancedSearch/Header.tsx
+++ b/components/AdvancedSearch/Header.tsx
@@ -1,5 +1,6 @@
 import { Button } from 'components/Button';
 import { GridListSelector } from 'components/GridListSelector';
+import { pirsch } from 'lib/pirsch';
 import { useCallback } from 'react';
 import { LoanStatus } from 'types/generated/graphql/nftLoans';
 import styles from './AdvancedSearch.module.css';
@@ -26,7 +27,7 @@ export function SearchHeader({
       ? 'Advanced search closed'
       : 'Advanced search opened';
     setShowSearch(!showSearch);
-    window.pirsch(message, {});
+    pirsch(message, {});
   }, [setShowSearch, showSearch]);
   return (
     <div className={styles.header}>

--- a/components/ConnectWallet/ConnectWallet.tsx
+++ b/components/ConnectWallet/ConnectWallet.tsx
@@ -2,6 +2,7 @@ import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { Button, ButtonLink } from 'components/Button';
 import { DisplayAddress } from 'components/DisplayAddress';
 import { useConfig } from 'hooks/useConfig';
+import { pirsch } from 'lib/pirsch';
 import React from 'react';
 import styles from './ConnectWallet.module.css';
 
@@ -13,7 +14,7 @@ export const ConnectWallet = () => {
         !account ? (
           <Button
             onClick={() => {
-              window.pirsch('Wallet connection modal opened', {});
+              pirsch('Wallet connection modal opened', {});
               openConnectModal();
             }}
             type="button">

--- a/components/NFTCollateralPicker/NFTCollateralPicker.tsx
+++ b/components/NFTCollateralPicker/NFTCollateralPicker.tsx
@@ -9,6 +9,7 @@ import { NFTEntity } from 'types/NFT';
 import { useTokenMetadata } from 'hooks/useTokenMetadata';
 import { ethers } from 'ethers';
 import { getNftContractAddress } from 'lib/eip721Subraph';
+import { pirsch } from 'lib/pirsch';
 
 interface NFTCollateralPickerProps {
   connectedWallet: string;
@@ -48,7 +49,7 @@ export function NFTCollateralPicker({
 
   const handleNFTClick = useCallback(
     (nft: NFTEntity) => {
-      window.pirsch('NFT Selected', { meta: { id: nft.id } });
+      pirsch('NFT Selected', { meta: { id: nft.id } });
       handleSetSelectedNFT(nft);
       dialog.setVisible(false);
     },

--- a/lib/pirsch.ts
+++ b/lib/pirsch.ts
@@ -1,4 +1,5 @@
 export const pirsch: typeof window.pirsch = (...args) => {
+  // Pirsch may be blocked by extensions; only try to send if it really exists
   if (window.pirsch) {
     window.pirsch(...args);
   }

--- a/lib/pirsch.ts
+++ b/lib/pirsch.ts
@@ -1,0 +1,5 @@
+export const pirsch: typeof window.pirsch = (...args) => {
+  if (window.pirsch) {
+    window.pirsch(...args);
+  }
+};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/176231473-5c45bdf4-9665-45c4-aae1-1b6515927de5.png)

This happened on Firefox with an adblocker; disabling adblocker fixed it. When window.pirsch isn't present the error blocked launching the wallet modal. Now we have a wrapper function that always checks before using.