### PR TITLE
fix: matching color for clickable Select

### DIFF
--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -80,7 +80,10 @@ export function Select<
         }),
         dropdownIndicator: (provided) => ({
           ...provided,
-          color: 'var(--neutral-100)',
+          color:
+            color === 'clickable'
+              ? 'var(--highlight-clickable-100)'
+              : 'var(--neutral-100)',
         }),
         menu: (provided) => ({
           ...provided,


### PR DESCRIPTION
taken from #722, giving its own PR since it isn't strictly related to community page. Just makes it so we have a blue chevron when we're on the blue Select variant. This was a QA request from @jringenberg 