### PR TITLE
feat: get all accessories from Graph

### DIFF
--- a/__tests__/lib/community.test.ts
+++ b/__tests__/lib/community.test.ts
@@ -1,6 +1,7 @@
-import { getCommunityAccountInfo } from 'lib/community';
+import { getAccessoryLookup, getCommunityAccountInfo } from 'lib/community';
 import { COMMUNITY_NFT_SUBGRAPH } from 'lib/constants';
 import { clientFromUrl } from 'lib/urql';
+import { Accessory } from 'types/generated/graphql/communitysubgraph';
 
 jest.mock('lib/urql', () => ({
   ...jest.requireActual('lib/urql'),
@@ -17,40 +18,88 @@ const mockedClientFromUrl = clientFromUrl as jest.MockedFunction<
 
 const address = '0xe89cb2053a04daf86abaa1f4bc6d50744e57d39e';
 
-describe('getCommunityAccountInfo', () => {
-  beforeEach(() => {
-    mockedClientFromUrl.mockReturnValue({
-      query: () => ({
-        toPromise: async () => ({ data: null } as any),
-      }),
-    } as any);
-  });
+describe('community NFT accessors', () => {
+  describe('getCommunityAccountInfo', () => {
+    beforeEach(() => {
+      mockedClientFromUrl.mockReturnValue({
+        query: () => ({
+          toPromise: async () => ({ data: null } as any),
+        }),
+      } as any);
+    });
 
-  it('returns the value of the query when available', async () => {
-    mockedClientFromUrl.mockReturnValue({
-      query: () => ({
-        toPromise: async () =>
-          ({
-            data: {
-              account: {
-                id: address,
+    it('returns the value of the query when available', async () => {
+      mockedClientFromUrl.mockReturnValue({
+        query: () => ({
+          toPromise: async () =>
+            ({
+              data: {
+                account: {
+                  id: address,
+                },
               },
-            },
-          } as any),
-      }),
-    } as any);
-    const result = await getCommunityAccountInfo(
-      address,
-      COMMUNITY_NFT_SUBGRAPH,
-    );
-    expect(result).toEqual({ id: address });
+            } as any),
+        }),
+      } as any);
+      const result = await getCommunityAccountInfo(
+        address,
+        COMMUNITY_NFT_SUBGRAPH,
+      );
+      expect(result).toEqual({ id: address });
+    });
+
+    it('returns null when the value is not available', async () => {
+      const result = await getCommunityAccountInfo(
+        address,
+        COMMUNITY_NFT_SUBGRAPH,
+      );
+      expect(result).toEqual(null);
+    });
   });
 
-  it('returns null when the value is not available', async () => {
-    const result = await getCommunityAccountInfo(
-      address,
-      COMMUNITY_NFT_SUBGRAPH,
-    );
-    expect(result).toEqual(null);
+  describe('getAccessoryLookup', () => {
+    const accessory1: Accessory = {
+      id: '1',
+      name: 'The First Accessory',
+      contractAddress: '0xcontract1',
+    };
+    const accessory2: Accessory = {
+      id: '2',
+      name: 'The Second Accessory',
+      contractAddress: '0xcontract2',
+    };
+    beforeEach(() => {
+      mockedClientFromUrl.mockReturnValue({
+        query: () => ({
+          toPromise: async () => ({ data: null } as any),
+        }),
+      } as any);
+    });
+
+    it('constructs a lookup table when data is available', async () => {
+      // since we loop to make tests below it's good to make sure we actually fire the expected number of asserts
+      expect.assertions(6);
+      mockedClientFromUrl.mockReturnValue({
+        query: () => ({
+          toPromise: async () =>
+            ({
+              data: {
+                accessories: [accessory1, accessory2],
+              },
+            } as any),
+        }),
+      } as any);
+      const result = await getAccessoryLookup(COMMUNITY_NFT_SUBGRAPH);
+      [accessory1, accessory2].forEach((acc) => {
+        expect(result[acc.id]).toEqual(acc);
+        expect(result[acc.name]).toEqual(acc);
+        expect(result[acc.contractAddress]).toEqual(acc);
+      });
+    });
+
+    it('returns empty obj when the value is not available', async () => {
+      const result = await getAccessoryLookup(COMMUNITY_NFT_SUBGRAPH);
+      expect(result).toEqual({});
+    });
   });
 });

--- a/graphql/community/accessoriesQuery.graphql
+++ b/graphql/community/accessoriesQuery.graphql
@@ -1,0 +1,7 @@
+query accessories {
+  accessories {
+    id
+    name
+    contractAddress
+  }
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -25,3 +25,5 @@ export const BUNNY_IMG_URL_MAP = {
 
 export const COMMUNITY_NFT_CONTRACT_ADDRESS =
   '0x7887bad2a088027dabce45c81229092a4112f622';
+export const COMMUNITY_NFT_SUBGRAPH =
+  'https://api.thegraph.com/subgraphs/name/with-backed/backed-community-nft-rinkeby';


### PR DESCRIPTION
pulled from #722, this is a wrapper function that gets all the accessories from the graph and creates a lookup table where you can find an accessory by any of: name, id, or contract address.