### PR TITLE
fix: improve community page network special case

### DIFF
--- a/components/ApplicationProviders/ApplicationProviders.tsx
+++ b/components/ApplicationProviders/ApplicationProviders.tsx
@@ -28,24 +28,22 @@ const Disclaimer: DisclaimerComponent = ({ Text, Link }) => (
   </Text>
 );
 
+const CHAINS = [chain.rinkeby, chain.mainnet, chain.polygon, chain.optimism];
+
 type ApplicationProvidersProps = {};
 export const ApplicationProviders = ({
   children,
 }: PropsWithChildren<ApplicationProvidersProps>) => {
   const { infuraId, alchemyId, network } = useConfig();
 
-  const { provider, chains } = useMemo(
-    () =>
-      configureChains(
-        [chain[network as ChainName]],
-        [
-          alchemyProvider({ alchemyId }),
-          infuraProvider({ infuraId }),
-          publicProvider(),
-        ],
-      ),
-    [alchemyId, infuraId, network],
-  );
+  const { provider, chains } = useMemo(() => {
+    const c = chain[network as ChainName];
+    return configureChains(c ? [c] : CHAINS, [
+      alchemyProvider({ alchemyId }),
+      infuraProvider({ infuraId }),
+      publicProvider(),
+    ]);
+  }, [alchemyId, infuraId, network]);
 
   const { connectors } = useMemo(
     () =>

--- a/components/ApplicationProviders/ApplicationProviders.tsx
+++ b/components/ApplicationProviders/ApplicationProviders.tsx
@@ -4,29 +4,17 @@ import {
   RainbowKitProvider,
   DisclaimerComponent,
 } from '@rainbow-me/rainbowkit';
+import { ChainName } from '@wagmi/core/dist/declarations/src/constants/chains';
 import { CachedRatesProvider } from 'hooks/useCachedRates/useCachedRates';
 import { useConfig } from 'hooks/useConfig';
 import { GlobalMessagingProvider } from 'hooks/useGlobalMessages';
 import { HasCollapsedHeaderInfoProvider } from 'hooks/useHasCollapsedHeaderInfo';
 import { TimestampProvider } from 'hooks/useTimestamp/useTimestamp';
 import React, { PropsWithChildren, useMemo } from 'react';
-import {
-  WagmiConfig,
-  chain,
-  Chain,
-  createClient,
-  configureChains,
-} from 'wagmi';
+import { WagmiConfig, chain, createClient, configureChains } from 'wagmi';
 import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { infuraProvider } from 'wagmi/providers/infura';
 import { publicProvider } from 'wagmi/providers/public';
-
-const CHAINS: Chain[] = [
-  { ...chain.rinkeby, name: 'Rinkeby' },
-  { ...chain.mainnet, name: 'Ethereum' },
-  { ...chain.optimism, name: 'Optimism' },
-  { ...chain.polygon, name: 'Polygon' },
-];
 
 const Disclaimer: DisclaimerComponent = ({ Text, Link }) => (
   <Text>
@@ -44,16 +32,19 @@ type ApplicationProvidersProps = {};
 export const ApplicationProviders = ({
   children,
 }: PropsWithChildren<ApplicationProvidersProps>) => {
-  const { infuraId, alchemyId } = useConfig();
+  const { infuraId, alchemyId, network } = useConfig();
 
   const { provider, chains } = useMemo(
     () =>
-      configureChains(CHAINS, [
-        alchemyProvider({ alchemyId }),
-        infuraProvider({ infuraId }),
-        publicProvider(),
-      ]),
-    [alchemyId, infuraId],
+      configureChains(
+        [chain[network as ChainName]],
+        [
+          alchemyProvider({ alchemyId }),
+          infuraProvider({ infuraId }),
+          publicProvider(),
+        ],
+      ),
+    [alchemyId, infuraId, network],
   );
 
   const { connectors } = useMemo(

--- a/components/CommunityHeader/CommunityHeader.tsx
+++ b/components/CommunityHeader/CommunityHeader.tsx
@@ -159,13 +159,10 @@ export function CommunityHeaderView({
       )}
       <div className={styles.cta}>
         <h3>🖼🐇 Community NFT</h3>
-        {account?.token?.id && (
-          <NFTExchangeAddressLink
-            contractAddress={COMMUNITY_NFT_CONTRACT_ADDRESS}
-            forceNetwork="optimism"
-            assetId={account.token.id}
-          />
-        )}
+        <NFTExchangeAddressLink
+          contractAddress={COMMUNITY_NFT_CONTRACT_ADDRESS}
+          assetId={account?.token.id || ''}
+        />
         <DescriptionList>
           <dt>Address</dt>
           <dd>{address}</dd>
@@ -281,13 +278,10 @@ export function CommunityHeaderManage({
       )}
       <div className={styles.cta}>
         <h3>🖼🐇 Community NFT</h3>
-        {account?.token?.id && (
-          <NFTExchangeAddressLink
-            contractAddress={COMMUNITY_NFT_CONTRACT_ADDRESS}
-            forceNetwork="optimism"
-            assetId={account.token.id}
-          />
-        )}
+        <NFTExchangeAddressLink
+          contractAddress={COMMUNITY_NFT_CONTRACT_ADDRESS}
+          assetId={account?.token.id || ''}
+        />
         <DescriptionList>
           <dt>Address</dt>
           <dd>{address}</dd>

--- a/components/ErrorBanners/ErrorBanners.tsx
+++ b/components/ErrorBanners/ErrorBanners.tsx
@@ -2,7 +2,7 @@ import { Banner } from 'components/Banner';
 import { WrongNetwork } from 'components/Banner/messages';
 import { useConfig } from 'hooks/useConfig';
 import { useGlobalMessages } from 'hooks/useGlobalMessages';
-import { configs, SupportedNetwork } from 'lib/config';
+import { SupportedNetwork } from 'lib/config';
 import { useRouter } from 'next/router';
 import React, { useMemo } from 'react';
 import styles from './ErrorBanners.module.css';
@@ -16,24 +16,13 @@ export function ErrorBanners() {
     [pathname],
   );
   const isAboutPage = useMemo(() => pathname === '/about', [pathname]);
-  const isCommunityPage = useMemo(
-    () => pathname.startsWith('/community'),
-    [pathname],
-  );
 
   return (
     <div className={styles.banners}>
-      {!isErrorPage && !isCommunityPage && !isAboutPage && (
+      {!isErrorPage && !isAboutPage && (
         <WrongNetwork
           expectedChainId={chainId}
           expectedChainName={network as SupportedNetwork}
-        />
-      )}
-      {isCommunityPage && (
-        /* Community page is not network-namespaced and only works on Optimism */
-        <WrongNetwork
-          expectedChainId={configs.optimism.chainId}
-          expectedChainName={configs.optimism.network as SupportedNetwork}
         />
       )}
       {messages.map((m) => {

--- a/components/EtherscanLink/EtherscanLink.tsx
+++ b/components/EtherscanLink/EtherscanLink.tsx
@@ -12,14 +12,7 @@ const EtherscanLink: FunctionComponent<EtherscanLinkProps> = ({
   ...props
 }) => {
   const { etherscanUrl } = useConfig();
-  const { pathname } = useRouter();
-  const isCommunityPage = useMemo(
-    () => pathname.startsWith('/community'),
-    [pathname],
-  );
-  const href = `${
-    isCommunityPage ? configs.optimism.etherscanUrl : etherscanUrl
-  }/${path}`;
+  const href = `${etherscanUrl}/${path}`;
   return (
     <a target="_blank" rel="noreferrer" {...props} href={href}>
       {children}

--- a/components/NFTExchangeLink/NFTExchangeLink.tsx
+++ b/components/NFTExchangeLink/NFTExchangeLink.tsx
@@ -18,22 +18,14 @@ const ADDRESS_LINK_PATH_PREFIX: { [key: string]: string } = {
 
 interface ExchangeLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   path: string;
-  forceNetwork?: SupportedNetwork;
 }
 const NFTExchangeLink: FunctionComponent<ExchangeLinkProps> = ({
   children,
-  forceNetwork,
   path,
   ...props
 }) => {
   const { openSeaUrl } = useConfig();
-  const url = useMemo(() => {
-    if (forceNetwork) {
-      return configs[forceNetwork].openSeaUrl;
-    }
-    return openSeaUrl;
-  }, [forceNetwork, openSeaUrl]);
-  const href = `${url}/${path}`;
+  const href = `${openSeaUrl}/${path}`;
   return (
     <a target="_blank" rel="noreferrer" {...props} href={href}>
       {children}
@@ -44,20 +36,16 @@ const NFTExchangeLink: FunctionComponent<ExchangeLinkProps> = ({
 interface NFTExchangeLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   contractAddress: string;
   assetId: string;
-  forceNetwork?: SupportedNetwork;
 }
 export const NFTExchangeAddressLink: FunctionComponent<
   NFTExchangeLinkProps
-> = ({ assetId, contractAddress, forceNetwork, ...props }) => {
+> = ({ assetId, contractAddress, ...props }) => {
   const { network } = useConfig();
   return (
     <NFTExchangeLink
-      path={`/${
-        ADDRESS_LINK_PATH_PREFIX[forceNetwork || network]
-      }/${contractAddress}/${assetId}`}
-      forceNetwork={forceNetwork}
+      path={`/${ADDRESS_LINK_PATH_PREFIX[network]}/${contractAddress}/${assetId}`}
       {...props}>
-      {ADDRESS_LINK_TEXT[forceNetwork || network]}
+      {ADDRESS_LINK_TEXT[network]}
     </NFTExchangeLink>
   );
 };

--- a/hooks/useConfig/useConfig.tsx
+++ b/hooks/useConfig/useConfig.tsx
@@ -1,5 +1,6 @@
 import { Config, configs, SupportedNetwork } from 'lib/config';
-import { createContext, FunctionComponent, useContext } from 'react';
+import { useRouter } from 'next/router';
+import { createContext, FunctionComponent, useContext, useMemo } from 'react';
 
 const ConfigContext = createContext<Config | null>(null);
 
@@ -19,5 +20,15 @@ export const ConfigProvider: FunctionComponent<ConfigProviderProps> = ({
 
 export function useConfig(): Config {
   const config = useContext(ConfigContext);
+  const { pathname } = useRouter();
+  const isCommunityPage = useMemo(
+    () => pathname.startsWith('/community'),
+    [pathname],
+  );
+
+  if (isCommunityPage) {
+    return configs.optimism;
+  }
+
   return config!;
 }


### PR DESCRIPTION
Got a report on Discord that the community page would try to swap networks to Rinkeby when connecting.
![image](https://user-images.githubusercontent.com/9300702/178750159-78c84bc8-968b-466f-aea3-189467515f49.png)

AFAICT, this is because Rinkeby is the first chain in our big list of chains. Now that the community page stuff has solidified a bit more, this PR reorganizes things and makes it so that:

- `useConfig` is special-cased to always return the Optimism config on community routes
  - this actually simplifies a number of things and makes us more robust in general
- `ApplicationProviders` sets up _only_ the required chain in a particular part of the network hierarchy
  - changing networks will cause it to reinstantiate the `wagmi` config with the new network

In my own testing this appears to resolve the erroneous network selection request. `McOso` who reported this didn't seem to have the same success, but I still think this PR is at a minimum a move in the right direction.