### PR TITLE
fix: don't allow loans denominated in MATIC

### DIFF
--- a/components/CreatePageHeader/CreatePageForm.tsx
+++ b/components/CreatePageHeader/CreatePageForm.tsx
@@ -78,8 +78,6 @@ export function CreatePageForm({
   const [loanAssetOptions, setLoanAssetOptions] = useState<LoanAsset[]>([]);
   const [hasReviewed, setHasReviewed] = useState(false);
 
-  console.log({ loanAssetOptions });
-
   const watchAllFields = watch();
 
   const wait = useCallback(async () => {

--- a/components/CreatePageHeader/CreatePageForm.tsx
+++ b/components/CreatePageHeader/CreatePageForm.tsx
@@ -78,6 +78,8 @@ export function CreatePageForm({
   const [loanAssetOptions, setLoanAssetOptions] = useState<LoanAsset[]>([]);
   const [hasReviewed, setHasReviewed] = useState(false);
 
+  console.log({ loanAssetOptions });
+
   const watchAllFields = watch();
 
   const wait = useCallback(async () => {
@@ -174,7 +176,7 @@ export function CreatePageForm({
     const response = await fetch(`/api/network/${network}/loanAssets`);
     const tokens: LoanAsset[] | null = await response.json();
     if (tokens) {
-      setLoanAssetOptions(tokens);
+      setLoanAssetOptions(tokens.filter((t) => t.symbol !== 'MATIC'));
     }
   }, [network]);
 

--- a/components/CreatePageHeader/CreatePageForm.tsx
+++ b/components/CreatePageHeader/CreatePageForm.tsx
@@ -176,6 +176,7 @@ export function CreatePageForm({
     const response = await fetch(`/api/network/${network}/loanAssets`);
     const tokens: LoanAsset[] | null = await response.json();
     if (tokens) {
+      // MATIC doesn't allow users to set allowance. TODO: make this more robust when we need it elsewhere.
       setLoanAssetOptions(tokens.filter((t) => t.symbol !== 'MATIC'));
     }
   }, [network]);


### PR DESCRIPTION
We received a report on discord about a user being unable to set their allowance for MATIC. It turns out that MATIC doesn't allow you to set an allowance.

This PR filters out MATIC from the list of available tokens (doing this client-side for now as a quick fix). Verified that before this filter, there were 17 available assets on Polygon; after the filter there were 16.