### PR TITLE
fix: initially connects to mainnet rather than rinkeby

### DIFF
--- a/components/ApplicationProviders/ApplicationProviders.tsx
+++ b/components/ApplicationProviders/ApplicationProviders.tsx
@@ -22,10 +22,10 @@ import { infuraProvider } from 'wagmi/providers/infura';
 import { publicProvider } from 'wagmi/providers/public';
 
 const CHAINS: Chain[] = [
-  { ...chain.rinkeby, name: 'Rinkeby' },
   { ...chain.mainnet, name: 'Ethereum' },
   { ...chain.optimism, name: 'Optimism' },
   { ...chain.polygon, name: 'Polygon' },
+  { ...chain.rinkeby, name: 'Rinkeby' },
 ];
 
 const Disclaimer: DisclaimerComponent = ({ Text, Link }) => (


### PR DESCRIPTION
- This is a bandaid fix until we implement `initialChain` in RainbowKit.
- This would make mainnet the initialChain you are connected to instead of rinkeby.