### PR TITLE
fix: simplify config handling for community page

### DIFF
--- a/components/CommunityHeader/CommunityHeader.tsx
+++ b/components/CommunityHeader/CommunityHeader.tsx
@@ -168,7 +168,6 @@ export function CommunityHeaderView({
         {account?.token?.id && (
           <NFTExchangeAddressLink
             contractAddress={COMMUNITY_NFT_CONTRACT_ADDRESS}
-            forceNetwork="optimism"
             assetId={account.token.id}
           />
         )}
@@ -290,7 +289,6 @@ export function CommunityHeaderManage({
         {account?.token?.id && (
           <NFTExchangeAddressLink
             contractAddress={COMMUNITY_NFT_CONTRACT_ADDRESS}
-            forceNetwork="optimism"
             assetId={account.token.id}
           />
         )}

--- a/components/ErrorBanners/ErrorBanners.tsx
+++ b/components/ErrorBanners/ErrorBanners.tsx
@@ -2,7 +2,7 @@ import { Banner } from 'components/Banner';
 import { WrongNetwork } from 'components/Banner/messages';
 import { useConfig } from 'hooks/useConfig';
 import { useGlobalMessages } from 'hooks/useGlobalMessages';
-import { configs, SupportedNetwork } from 'lib/config';
+import { SupportedNetwork } from 'lib/config';
 import { useRouter } from 'next/router';
 import React, { useMemo } from 'react';
 import styles from './ErrorBanners.module.css';
@@ -16,24 +16,13 @@ export function ErrorBanners() {
     [pathname],
   );
   const isAboutPage = useMemo(() => pathname === '/about', [pathname]);
-  const isCommunityPage = useMemo(
-    () => pathname.startsWith('/community'),
-    [pathname],
-  );
 
   return (
     <div className={styles.banners}>
-      {!isErrorPage && !isCommunityPage && !isAboutPage && (
+      {!isErrorPage && !isAboutPage && (
         <WrongNetwork
           expectedChainId={chainId}
           expectedChainName={network as SupportedNetwork}
-        />
-      )}
-      {isCommunityPage && (
-        /* Community page is not network-namespaced and only works on Optimism */
-        <WrongNetwork
-          expectedChainId={configs.optimism.chainId}
-          expectedChainName={configs.optimism.network as SupportedNetwork}
         />
       )}
       {messages.map((m) => {

--- a/components/EtherscanLink/EtherscanLink.tsx
+++ b/components/EtherscanLink/EtherscanLink.tsx
@@ -1,7 +1,5 @@
 import { useConfig } from 'hooks/useConfig';
-import { configs } from 'lib/config';
-import { useRouter } from 'next/router';
-import React, { AnchorHTMLAttributes, FunctionComponent, useMemo } from 'react';
+import React, { AnchorHTMLAttributes, FunctionComponent } from 'react';
 
 interface EtherscanLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   path: string;
@@ -12,14 +10,7 @@ const EtherscanLink: FunctionComponent<EtherscanLinkProps> = ({
   ...props
 }) => {
   const { etherscanUrl } = useConfig();
-  const { pathname } = useRouter();
-  const isCommunityPage = useMemo(
-    () => pathname.startsWith('/community'),
-    [pathname],
-  );
-  const href = `${
-    isCommunityPage ? configs.optimism.etherscanUrl : etherscanUrl
-  }/${path}`;
+  const href = `${etherscanUrl}/${path}`;
   return (
     <a target="_blank" rel="noreferrer" {...props} href={href}>
       {children}

--- a/components/NFTExchangeLink/NFTExchangeLink.tsx
+++ b/components/NFTExchangeLink/NFTExchangeLink.tsx
@@ -1,6 +1,5 @@
 import { useConfig } from 'hooks/useConfig';
-import { configs, SupportedNetwork } from 'lib/config';
-import React, { AnchorHTMLAttributes, FunctionComponent, useMemo } from 'react';
+import React, { AnchorHTMLAttributes, FunctionComponent } from 'react';
 
 const ADDRESS_LINK_TEXT: { [key: string]: string } = {
   rinkeby: 'View on OpenSea',
@@ -18,22 +17,14 @@ const ADDRESS_LINK_PATH_PREFIX: { [key: string]: string } = {
 
 interface ExchangeLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   path: string;
-  forceNetwork?: SupportedNetwork;
 }
 const NFTExchangeLink: FunctionComponent<ExchangeLinkProps> = ({
   children,
-  forceNetwork,
   path,
   ...props
 }) => {
   const { openSeaUrl } = useConfig();
-  const url = useMemo(() => {
-    if (forceNetwork) {
-      return configs[forceNetwork].openSeaUrl;
-    }
-    return openSeaUrl;
-  }, [forceNetwork, openSeaUrl]);
-  const href = `${url}/${path}`;
+  const href = `${openSeaUrl}/${path}`;
   return (
     <a target="_blank" rel="noreferrer" {...props} href={href}>
       {children}
@@ -44,20 +35,16 @@ const NFTExchangeLink: FunctionComponent<ExchangeLinkProps> = ({
 interface NFTExchangeLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   contractAddress: string;
   assetId: string;
-  forceNetwork?: SupportedNetwork;
 }
 export const NFTExchangeAddressLink: FunctionComponent<
   NFTExchangeLinkProps
-> = ({ assetId, contractAddress, forceNetwork, ...props }) => {
+> = ({ assetId, contractAddress, ...props }) => {
   const { network } = useConfig();
   return (
     <NFTExchangeLink
-      path={`/${
-        ADDRESS_LINK_PATH_PREFIX[forceNetwork || network]
-      }/${contractAddress}/${assetId}`}
-      forceNetwork={forceNetwork}
+      path={`/${ADDRESS_LINK_PATH_PREFIX[network]}/${contractAddress}/${assetId}`}
       {...props}>
-      {ADDRESS_LINK_TEXT[forceNetwork || network]}
+      {ADDRESS_LINK_TEXT[network]}
     </NFTExchangeLink>
   );
 };

--- a/hooks/useConfig/useConfig.tsx
+++ b/hooks/useConfig/useConfig.tsx
@@ -1,5 +1,6 @@
 import { Config, configs, SupportedNetwork } from 'lib/config';
-import { createContext, FunctionComponent, useContext } from 'react';
+import { useRouter } from 'next/router';
+import { createContext, FunctionComponent, useContext, useMemo } from 'react';
 
 const ConfigContext = createContext<Config | null>(null);
 
@@ -19,5 +20,15 @@ export const ConfigProvider: FunctionComponent<ConfigProviderProps> = ({
 
 export function useConfig(): Config {
   const config = useContext(ConfigContext);
+  const { pathname } = useRouter();
+  const isCommunityPage = useMemo(
+    () => pathname.startsWith('/community'),
+    [pathname],
+  );
+
+  if (isCommunityPage) {
+    return configs.optimism;
+  }
+
   return config!;
 }


### PR DESCRIPTION
Taken from #747. We had some sprawling complexity by special-casing handling of values for the community page. This PR fixes that by ensuring `useConfig` always returns the Optimism config on community routes.