### PR TITLE
NFT-96 fix: pass chainId when instantiating ethers.Provider

### DIFF
--- a/components/CreatePageHeader/CreatePageForm.tsx
+++ b/components/CreatePageHeader/CreatePageForm.tsx
@@ -108,6 +108,7 @@ export function CreatePageForm({
       const assetContract = jsonRpcERC20Contract(
         denomination.address,
         jsonRpcProvider,
+        network as SupportedNetwork,
       );
       const loanAssetDecimals = await assetContract.decimals();
       const durationInSeconds = Math.ceil(parsedDuration * SECONDS_IN_A_DAY);

--- a/components/CreatePageHeader/Explainer.tsx
+++ b/components/CreatePageHeader/Explainer.tsx
@@ -2,6 +2,7 @@ import { Explainer as ExplainerWrapper } from 'components/Explainer';
 import { ethers } from 'ethers';
 import { formatUnits } from 'ethers/lib/utils';
 import { useConfig } from 'hooks/useConfig';
+import { SupportedNetwork } from 'lib/config';
 import { jsonRpcERC20Contract } from 'lib/contracts';
 import { estimatedRepayment } from 'lib/loans/utils';
 import React, { useEffect, useState } from 'react';
@@ -34,7 +35,7 @@ export const explainers: {
 };
 
 export function Explainer({ form, state, top }: ExplainerProps) {
-  const { jsonRpcProvider } = useConfig();
+  const { jsonRpcProvider, network } = useConfig();
   const context = form.watch();
   const [decimals, setDecimals] = useState<number | null>(null);
   useEffect(() => {
@@ -42,10 +43,11 @@ export function Explainer({ form, state, top }: ExplainerProps) {
       const loanAssetContract = jsonRpcERC20Contract(
         context.denomination.address,
         jsonRpcProvider,
+        network as SupportedNetwork,
       );
       loanAssetContract.decimals().then(setDecimals);
     }
-  }, [context.denomination, jsonRpcProvider, setDecimals]);
+  }, [context.denomination, jsonRpcProvider, network, setDecimals]);
 
   const error = Object.values(form.formState.errors)[0];
   const Inner = explainers[state] || null;

--- a/components/LoanTermsDisclosure/LoanTermsDisclosure.tsx
+++ b/components/LoanTermsDisclosure/LoanTermsDisclosure.tsx
@@ -3,6 +3,7 @@ import { DescriptionList } from 'components/DescriptionList';
 import { Balance } from 'components/LoanForm/Balance';
 import { ethers } from 'ethers';
 import { useConfig } from 'hooks/useConfig';
+import { SupportedNetwork } from 'lib/config';
 import { jsonRpcERC20Contract } from 'lib/contracts';
 import { estimatedRepayment } from 'lib/loans/utils';
 import React, { useEffect, useState } from 'react';
@@ -62,17 +63,18 @@ export function LoanTermsDisclosure({
 }
 
 function CreatePageTerms({ fields }: Pick<LoanTermsDisclosureProps, 'fields'>) {
-  const { jsonRpcProvider } = useConfig();
+  const { jsonRpcProvider, network } = useConfig();
   const [decimals, setDecimals] = useState<number | null>(null);
   useEffect(() => {
     if (fields.denomination) {
       const loanAssetContract = jsonRpcERC20Contract(
         fields.denomination.address,
         jsonRpcProvider,
+        network as SupportedNetwork,
       );
       loanAssetContract.decimals().then(setDecimals);
     }
-  }, [fields.denomination, jsonRpcProvider, setDecimals]);
+  }, [fields.denomination, jsonRpcProvider, network, setDecimals]);
 
   if (!fieldsAreFull(fields) || !decimals) {
     return null;
@@ -134,17 +136,18 @@ function LendPageTerms({
   balance,
 }: Pick<LoanTermsDisclosureProps, 'fields'> &
   Pick<LoanTermsDisclosureProps, 'balance'>) {
-  const { jsonRpcProvider } = useConfig();
+  const { jsonRpcProvider, network } = useConfig();
   const [decimals, setDecimals] = useState<number | null>(null);
   useEffect(() => {
     if (fields.denomination) {
       const loanAssetContract = jsonRpcERC20Contract(
         fields.denomination.address,
         jsonRpcProvider,
+        network as SupportedNetwork,
       );
       loanAssetContract.decimals().then(setDecimals);
     }
-  }, [fields.denomination, jsonRpcProvider, setDecimals]);
+  }, [fields.denomination, jsonRpcProvider, network, setDecimals]);
 
   if (!fieldsAreFull(fields) || !decimals) {
     return null;
@@ -178,7 +181,7 @@ function BuyoutPageTerms({
   Pick<LoanTermsDisclosureProps, 'balance'> &
   Pick<LoanTermsDisclosureProps, 'accrued'> &
   Pick<LoanTermsDisclosureProps, 'totalPayback'>) {
-  const { jsonRpcProvider } = useConfig();
+  const { jsonRpcProvider, network } = useConfig();
   const [decimals, setDecimals] = useState<number | null>(null);
 
   useEffect(() => {
@@ -186,10 +189,11 @@ function BuyoutPageTerms({
       const loanAssetContract = jsonRpcERC20Contract(
         fields.denomination.address,
         jsonRpcProvider,
+        network as SupportedNetwork,
       );
       loanAssetContract.decimals().then(setDecimals);
     }
-  }, [fields.denomination, jsonRpcProvider, setDecimals]);
+  }, [fields.denomination, jsonRpcProvider, network, setDecimals]);
 
   if (!fieldsAreFull(fields) || !decimals) {
     return null;

--- a/components/LoanTickets/LoanTickets.tsx
+++ b/components/LoanTickets/LoanTickets.tsx
@@ -25,6 +25,7 @@ function BorrowerColumn({ loan }: BorrowerColumnProps) {
   const BORROW_CONTRACT = jsonRpcERC721Contract(
     contractDirectory[network as SupportedNetwork].borrowTicket,
     jsonRpcProvider,
+    network as SupportedNetwork,
   );
 
   return (
@@ -59,6 +60,7 @@ function LenderColumn({ loan }: LenderColumnProps) {
   const LEND_CONTRACT = jsonRpcERC721Contract(
     contractDirectory[network as SupportedNetwork].lendTicket,
     jsonRpcProvider,
+    network as SupportedNetwork,
   );
 
   if (!loan.lender) {

--- a/hooks/useBalance/useBalance.ts
+++ b/hooks/useBalance/useBalance.ts
@@ -1,13 +1,14 @@
 import { ethers } from 'ethers';
 import { useConfig } from 'hooks/useConfig';
 import { useTimestamp } from 'hooks/useTimestamp';
+import { SupportedNetwork } from 'lib/config';
 import { jsonRpcERC20Contract } from 'lib/contracts';
 import { useCallback, useEffect, useState } from 'react';
 import { useAccount } from 'wagmi';
 
 export function useBalance(assetContractAddress: string) {
   const { address } = useAccount();
-  const { jsonRpcProvider } = useConfig();
+  const { jsonRpcProvider, network } = useConfig();
   const timestamp = useTimestamp();
 
   const [balance, setBalance] = useState<number>(0);
@@ -20,6 +21,7 @@ export function useBalance(assetContractAddress: string) {
       const assetContract = jsonRpcERC20Contract(
         assetContractAddress,
         jsonRpcProvider,
+        network as SupportedNetwork,
       );
       const [balance, decimals] = await Promise.all([
         assetContract.balanceOf(address),
@@ -32,7 +34,7 @@ export function useBalance(assetContractAddress: string) {
       setBalance(humanReadableBalance);
     },
     // timestamp included as a dep to force refresh whenever timestamp updates (should indicate new block)
-    [address, assetContractAddress, jsonRpcProvider, timestamp],
+    [address, assetContractAddress, jsonRpcProvider, network, timestamp],
   );
 
   useEffect(() => {

--- a/hooks/useTimestamp/useTimestamp.tsx
+++ b/hooks/useTimestamp/useTimestamp.tsx
@@ -18,11 +18,11 @@ export const TimestampContext = createContext<number | null>(null);
 
 export function TimestampProvider({ children }: PropsWithChildren<{}>) {
   const [timestamp, setTimestamp] = useState<number | null>(null);
-  const { jsonRpcProvider } = useConfig();
+  const { jsonRpcProvider, chainId } = useConfig();
 
   const provider = useMemo(() => {
-    return new ethers.providers.JsonRpcProvider(jsonRpcProvider);
-  }, [jsonRpcProvider]);
+    return new ethers.providers.JsonRpcProvider(jsonRpcProvider, chainId);
+  }, [chainId, jsonRpcProvider]);
 
   useEffect(() => {
     const setLatestTimestamp = async () => {

--- a/lib/account.ts
+++ b/lib/account.ts
@@ -11,6 +11,7 @@ export async function getAccountLoanAssetAllowance(
   const assetContract = jsonRpcERC20Contract(
     loanAssetContractAddress,
     jsonRpcProvider,
+    network,
   );
   return assetContract.allowance(
     account as string,
@@ -24,7 +25,11 @@ export function waitForApproval(
   jsonRpcProvider: string,
   network: SupportedNetwork,
 ) {
-  const contract = jsonRpcERC20Contract(contractAddress, jsonRpcProvider);
+  const contract = jsonRpcERC20Contract(
+    contractAddress,
+    jsonRpcProvider,
+    network,
+  );
   const filter = contract.filters.Approval(
     account,
     contractDirectory[network].loanFacilitator,

--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -6,7 +6,7 @@ import {
   ERC721__factory,
   NFTLoanFacilitator__factory,
 } from 'types/generated/abis';
-import { SupportedNetwork } from './config';
+import { configs, SupportedNetwork } from './config';
 import { COMMUNITY_NFT_CONTRACT_ADDRESS } from './constants';
 
 type ContractDirectoryListing = {
@@ -42,11 +42,18 @@ export function web3LoanFacilitator(signer: Signer, network: SupportedNetwork) {
   return loanFacilitator(signer, network);
 }
 
+function makeProvider(jsonRpcProvider: string, network: SupportedNetwork) {
+  return new ethers.providers.JsonRpcProvider(
+    jsonRpcProvider,
+    configs[network].chainId,
+  );
+}
+
 export function jsonRpcLoanFacilitator(
   jsonRpcProvider: string,
   network: SupportedNetwork,
 ) {
-  const provider = new ethers.providers.JsonRpcProvider(jsonRpcProvider);
+  const provider = makeProvider(jsonRpcProvider, network);
   return loanFacilitator(provider, network);
 }
 
@@ -61,13 +68,18 @@ export function web3Erc721Contract(address: string, signer: Signer) {
 export function jsonRpcERC721Contract(
   address: string,
   jsonRpcProvider: string,
+  network: SupportedNetwork,
 ): ERC721 {
-  const provider = new ethers.providers.JsonRpcProvider(jsonRpcProvider);
+  const provider = makeProvider(jsonRpcProvider, network);
   return erc721Contract(address, provider);
 }
 
-export function jsonRpcERC20Contract(address: string, jsonRpcProvider: string) {
-  const provider = new ethers.providers.JsonRpcProvider(jsonRpcProvider);
+export function jsonRpcERC20Contract(
+  address: string,
+  jsonRpcProvider: string,
+  network: SupportedNetwork,
+) {
+  const provider = makeProvider(jsonRpcProvider, network);
   return erc20Contract(address, provider);
 }
 
@@ -100,7 +112,7 @@ export function web3CommunityNFT(signer: Signer) {
 }
 
 export function jsonRpcCommunityNFT(jsonRpcProvider: string) {
-  const provider = new ethers.providers.JsonRpcProvider(jsonRpcProvider);
+  const provider = makeProvider(jsonRpcProvider, 'optimism');
   return communityNFT(provider);
 }
 

--- a/lib/loans/collateralSaleInfo.ts
+++ b/lib/loans/collateralSaleInfo.ts
@@ -49,7 +49,7 @@ export async function getCollateralSaleInfo(
 async function getMostRecentSale(
   nftContractAddress: string,
   tokenId: string,
-  nftSalesSubgraph: string | null,
+  _nftSalesSubgraph: string | null, // TODO: deprecate
   network: SupportedNetwork,
   jsonRpcProvider: string,
 ): Promise<{ paymentToken: string; price: number } | null> {
@@ -73,6 +73,7 @@ async function getMostRecentSale(
   const erc20Contract = jsonRpcERC20Contract(
     paymentTokenAddress,
     jsonRpcProvider,
+    network,
   );
 
   let paymentTokenSymbol: string;

--- a/lib/loans/node/nodeLoanById.ts
+++ b/lib/loans/node/nodeLoanById.ts
@@ -18,10 +18,12 @@ export async function nodeLoanById(
   const lendTicket = jsonRpcERC721Contract(
     contractDirectory[network].lendTicket,
     jsonRpcProvider,
+    network,
   );
   const borrowTicket = jsonRpcERC721Contract(
     contractDirectory[network].borrowTicket,
     jsonRpcProvider,
+    network,
   );
 
   const loanInfo = await loanFacilitator.loanInfo(loanId);
@@ -41,6 +43,7 @@ export async function nodeLoanById(
   const loanAssetContract = jsonRpcERC20Contract(
     loanAssetContractAddress,
     jsonRpcProvider,
+    network,
   );
 
   const decimals = await loanAssetContract.decimals();
@@ -60,6 +63,7 @@ export async function nodeLoanById(
   const collateralAssetContract = jsonRpcERC721Contract(
     collateralContractAddress,
     jsonRpcProvider,
+    network,
   );
   const collateralTokenURI = await collateralAssetContract.tokenURI(
     collateralTokenId,

--- a/pages/api/network/[network]/nftInfo/[contractAddress]/[tokenId].ts
+++ b/pages/api/network/[network]/nftInfo/[contractAddress]/[tokenId].ts
@@ -47,7 +47,11 @@ export async function getMetadata(
 ): Promise<NFTResponseData> {
   try {
     const { jsonRpcProvider } = configs[network];
-    const contract = jsonRpcERC721Contract(contractAddress, jsonRpcProvider);
+    const contract = jsonRpcERC721Contract(
+      contractAddress,
+      jsonRpcProvider,
+      network,
+    );
     const uri = await contract.tokenURI(ethers.BigNumber.from(tokenId));
     const resolvedUri = convertIPFS(uri);
     if (!resolvedUri) {


### PR DESCRIPTION
Including the chainId when we instantiate a provider, this could minimize the number of calls to find out which chain to use