### PR TITLE
NFT-407 fix: Only HTTP(S) protocols are supported

### DIFF
--- a/lib/getNFTInfo.ts
+++ b/lib/getNFTInfo.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 import IPFSGatewayTools from '@pinata/ipfs-gateway-tools/dist/node';
 import { SupportedNetwork } from './config';
 
+const DATA_URI_MIME_REGEXP = /data:([^;]*)/;
 const ipfsGatewayTools = new IPFSGatewayTools();
 
 export type NFTResponseData = {
@@ -63,6 +64,13 @@ export async function getMimeType(mediaUrl?: string) {
 
   if (!mediaUrl) {
     return defaultMimeType;
+  }
+
+  if (mediaUrl.startsWith('data')) {
+    const matches = mediaUrl.match(DATA_URI_MIME_REGEXP);
+    if (matches && matches[1]) {
+      return matches[1];
+    }
   }
 
   try {


### PR DESCRIPTION
This should drastically reduce incidence of our most common Sentry error. tl;dr you can't fire off a HEAD request on a data URI to find its mimetype. This PR allows `getMimeType` to handle data URIs properly.