### PR TITLE
NFT-427 fix: sizing network selector in header

### DIFF
--- a/components/Header/Header.module.css
+++ b/components/Header/Header.module.css
@@ -29,7 +29,8 @@
 }
 
 .controls {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr minmax(0, 1fr);
   gap: 20px;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/180461931-d9743a30-2653-44ac-9bcc-d5fb9bcdf647.png)
![image](https://user-images.githubusercontent.com/9300702/180461966-ce557d90-dc1e-40d4-8547-151b2d49427a.png)

Working with React Select is a bit tricky, hard to make it size itself to its content. This way at least it always matches the width of the connect button.