### PR TITLE
NFT-428: Fix timely notifications firing off early

### DIFF
--- a/__tests__/api/events/cron/processTimelyEvents.test.ts
+++ b/__tests__/api/events/cron/processTimelyEvents.test.ts
@@ -5,6 +5,7 @@ import { sendEmailsForTriggerAndEntity } from 'lib/events/consumers/userNotifica
 import { createMocks } from 'node-mocks-http';
 import handler from 'pages/api/events/cron/processTimelyEvents';
 import { devConfigs } from 'lib/config';
+import { overrideLastWrittenTimestamp } from 'lib/events/consumers/userNotifications/repository';
 
 const aboutToExpireLoan = {
   ...subgraphLoan,
@@ -26,6 +27,10 @@ jest.mock('lib/events/timely/timely', () => ({
   getLiquidatedLoansForTimestamp: jest.fn(),
 }));
 
+jest.mock('lib/events/consumers/userNotifications/repository.ts', () => ({
+  overrideLastWrittenTimestamp: jest.fn(),
+}));
+
 const mockedGetLiquidatedLoansCall =
   getLiquidatedLoansForTimestamp as jest.MockedFunction<
     typeof getLiquidatedLoansForTimestamp
@@ -36,14 +41,21 @@ const mockedSendEmailCall =
     typeof sendEmailsForTriggerAndEntity
   >;
 
+const mockOverrideLastWrittenTimestampCall =
+  overrideLastWrittenTimestamp as jest.MockedFunction<
+    typeof overrideLastWrittenTimestamp
+  >;
+
 describe('/api/events/cron/processTimelyEvents', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     mockedGetLiquidatedLoansCall.mockResolvedValue({
       liquidationOccurringLoans: [aboutToExpireLoan],
       liquidationOccurredLoans: [alreadyExpiredLoan],
+      currentRunTimestamp: 0,
     });
     mockedSendEmailCall.mockResolvedValue();
+    mockOverrideLastWrittenTimestampCall.mockResolvedValue();
   });
 
   it('makes call to get liquidated loans, gets notifications associated with addresses, and sends emails', async () => {
@@ -71,6 +83,7 @@ describe('/api/events/cron/processTimelyEvents', () => {
         config,
       );
     });
+    expect(overrideLastWrittenTimestamp).toHaveBeenCalledTimes(1);
 
     expect(res._getStatusCode()).toBe(200);
     expect(JSON.parse(res._getData())).toEqual(

--- a/__tests__/lib/events/timely/timely.test.ts
+++ b/__tests__/lib/events/timely/timely.test.ts
@@ -34,7 +34,6 @@ jest.mock('lib/loans/subgraph/subgraphLoans', () => ({
 }));
 
 jest.mock('lib/events/consumers/userNotifications/repository', () => ({
-  overrideLastWrittenTimestamp: jest.fn(),
   getLastWrittenTimestamp: jest.fn(),
 }));
 
@@ -55,7 +54,6 @@ describe('getLiquidatedLoansForTimestamp', () => {
     jest.clearAllMocks();
     mockedGetExpiringLoansCall.mockResolvedValueOnce([aboutToExpireLoan]);
     mockedGetExpiringLoansCall.mockResolvedValueOnce([alreadyExpiredLoan]);
-    mockedOverrideLastTimestampCall.mockResolvedValue();
     mockedGetLastWrittenTimestampCall.mockResolvedValue(lastRun);
   });
 
@@ -79,8 +77,6 @@ describe('getLiquidatedLoansForTimestamp', () => {
       now,
       configs.rinkeby.nftBackedLoansSubgraph,
     );
-
-    expect(mockedOverrideLastTimestampCall).toHaveBeenCalledWith(now);
 
     expect(liquidationOccurringLoans).toEqual([aboutToExpireLoan]);
     expect(liquidationOccurredLoans).toEqual([alreadyExpiredLoan]);


### PR DESCRIPTION
We were calling `overrideLastWrittenTimestamp` for every config, meaning that we were fast forwarding our timely clock 3 hours instead of 1 (mainnet, optimism polygon). This meant that users were receiving notifications way earlier than they should have. This PR fixes this, by only calling `overrideLastWrittenTimestamp` once at the handler level