### PR TITLE
feat: display conversion on optimism and polygon

### DIFF
--- a/lib/coingecko.ts
+++ b/lib/coingecko.ts
@@ -1,5 +1,12 @@
 import { SupportedNetwork } from './config';
 
+// based on output from https://api.coingecko.com/api/v3/asset_platforms
+const networkMap = {
+  optimism: 'optimistic-ethereum',
+  ethereum: 'ethereum',
+  polygon: 'polygon-pos',
+};
+
 export async function getUnitPriceForCoin(
   tokenAddress: string,
   toCurrency: string,
@@ -9,9 +16,9 @@ export async function getUnitPriceForCoin(
     return 1.01;
   }
 
-  if (network === 'ethereum') {
+  if (network && networkMap[network]) {
     const statsRes = await fetch(
-      `https://api.coingecko.com/api/v3/coins/ethereum/contract/${tokenAddress}`,
+      `https://api.coingecko.com/api/v3/coins/${networkMap[network]}/contract/${tokenAddress}`,
     );
 
     const json = await statsRes.json();


### PR DESCRIPTION
This gets us on the road to NFT-374. Had to poke around the coingecko API to find what the correct network IDs for optimism and polygon are. As you can see from the screenshot (particularly Polygon), the API doesn't necessarily support _every_ token.

![image](https://user-images.githubusercontent.com/9300702/181108608-9457ff9e-98df-4caa-ae8d-fb314d6ac3da.png)
![image](https://user-images.githubusercontent.com/9300702/181108677-386bd498-a440-409e-b12b-e31a0a39bfcc.png)
